### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/putty
+* @tinted-theming/putty

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,6 +2,7 @@ The MIT License (MIT)
 =====================
 
 Copyright © `2016` `Anderson Bravalheri`
+Copyright © `2022` [`Tinted Theming`](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage
    [configured](http://www.grok2.com/blog/2013/12/01/putty-linux-terminal-xterm-emacs-256-colors/)
    to [provide](https://sanctum.geek.nz/arabesque/putty-configuration/)
    256 colors support;
-3. Choose your theme from the [base16-gallery](https://base16-project.github.io/base16-gallery/);
+3. Choose your theme from the [base16-gallery](https://tinted-theming.github.io/base16-gallery/);
 4. Locate the corresponding file in `putty` directory and download it;
 5. Edit the file, and change session name in
    `[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\` **`{{SESSION_NAME}}`** `]`
@@ -36,10 +36,10 @@ keep up to date with the latest changes.
 If you're you're looking to build the colorschemes manually to test out
 a change:
 
-1. Install [base16-builder-go](https://github.com/base16-project/base16-builder-go)
+1. Install [base16-builder-go](https://github.com/tinted-theming/base16-builder-go)
    or a compatible tool.
    (Note that in the case of `base16-builder-go`
-   the [releases' page](https://github.com/base16-project/base16-builder-go/releases)
+   the [releases' page](https://github.com/tinted-theming/base16-builder-go/releases)
    contains pre-built binaries that can be simply downloaded and executed).
 2. Execute the `builder` binary from the `base16-putty` directory.
    In the case of `base16-builder-go` no argument is required.
@@ -52,4 +52,4 @@ Thanks
 
 - @staticaland for the [original material](https://github.com/staticaland/base16-putty);
 - @iamthad and @ticky for [mapping](https://github.com/iamthad/base16-mintty) `base16` vars into color names used by PuTTY;
-- @chriskempson for the original conception of the [base16 project](https://github.com/base16-project/home).
+- @chriskempson for the original conception of the [tinted-theming](https://github.com/tinted-theming/home).

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,7 +1,8 @@
 Windows Registry Editor Version 5.00
 
 ; Base16 {{scheme-name}}
-; schema by {{scheme-author}}
+; Scheme author: {{scheme-author}}
+; Template author: Tinted Theming (https://github.com/tinted-theming)
 [HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\{{scheme-slug}}]
 
 ; Default Foreground


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.