### PR TITLE
Use lighter color for bold green, bold yellow, ...

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -39,25 +39,25 @@ Windows Registry Editor Version 5.00
 "Colour10"="{{base0B-rgb-r}},{{base0B-rgb-g}},{{base0B-rgb-b}}"
 
 ; ANSI Green Bold
-"Colour11"="{{base01-rgb-r}},{{base01-rgb-g}},{{base01-rgb-b}}"
+"Colour11"="{{base0B-rgb-r}},{{base0B-rgb-g}},{{base0B-rgb-b}}"
 
 ; ANSI Yellow
 "Colour12"="{{base0A-rgb-r}},{{base0A-rgb-g}},{{base0A-rgb-b}}"
 
 ; ANSI Yellow Bold
-"Colour13"="{{base02-rgb-r}},{{base02-rgb-g}},{{base02-rgb-b}}"
+"Colour13"="{{base0A-rgb-r}},{{base0A-rgb-g}},{{base0A-rgb-b}}"
 
 ; ANSI Blue
 "Colour14"="{{base0D-rgb-r}},{{base0D-rgb-g}},{{base0D-rgb-b}}"
 
 ; ANSI Blue Bold
-"Colour15"="{{base04-rgb-r}},{{base04-rgb-g}},{{base04-rgb-b}}"
+"Colour15"="{{base0D-rgb-r}},{{base0D-rgb-g}},{{base0D-rgb-b}}"
 
 ; ANSI Magenta
 "Colour16"="{{base0E-rgb-r}},{{base0E-rgb-g}},{{base0E-rgb-b}}"
 
 ; ANSI Magenta Bold
-"Colour17"="{{base06-rgb-r}},{{base06-rgb-g}},{{base06-rgb-b}}"
+"Colour17"="{{base0E-rgb-r}},{{base0E-rgb-g}},{{base0E-rgb-b}}"
 
 ; ANSI Cyan
 "Colour18"="{{base0C-rgb-r}},{{base0C-rgb-g}},{{base0C-rgb-b}}"
@@ -70,4 +70,3 @@ Windows Registry Editor Version 5.00
 
 ; ANSI White Bold
 "Colour21"="{{base07-rgb-r}},{{base07-rgb-g}},{{base07-rgb-b}}"
-


### PR DESCRIPTION
The original bold green color too hard to see, many theme of color0 and color1 are almost same, see below

![2023-02-13_17-30-27](https://user-images.githubusercontent.com/2720049/218422126-e0bbe6cd-2980-4aaf-84eb-6643798db122.png)

Change to use the same color of normal green

![2023-02-13_17-31-48](https://user-images.githubusercontent.com/2720049/218422292-f05658e6-ddc5-4ab8-98d0-51b8321312dd.png)
