### PR TITLE
Rename to tinted-putty and add Base24 template and themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
-base16-putty
+tinted-putty
 ============
 
-Base16 colors for PuTTY
+[Base16] and [Base24] colors for [PuTTY]
 
 
 Introduction
 ------------
 
 This project provides `.reg` files for configuring PuTTY colors
-according to the `base16 system`.
+according to the `base16 system` and `base24 system`.
+
+This repo was originally named `base16-putty`, but since we've now got
+the added [Base24] template and theme support, and maybe different ones
+in future, we renamed to `tinted-putty` so we don't lock ourselves into
+a single scheme system.
 
 
 Usage
 -----
 
 1. Make sure to have the most recent stable version of PuTTY;
-2. Make sure that your version is
-   [configured](https://web.archive.org/web/20140803065929/http://www.grok2.com/blog/2013/12/01/putty-linux-terminal-xterm-emacs-256-colors/)
-   to [provide](https://sanctum.geek.nz/arabesque/putty-configuration/)
-   256 colors support;
-3. Choose your theme from the [base16-gallery](https://tinted-theming.github.io/base16-gallery/);
+2. Make sure that your version is [configured] to [provide] 256 colors
+   support;
+3. Choose your theme from the [base16-gallery];
 4. Locate the corresponding file in `putty` directory and download it;
 5. Edit the file, and change session name in
    `[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\` **`{{SESSION_NAME}}`** `]`
@@ -28,7 +31,7 @@ Usage
 
 
 Issues or Contributions
-------------------------
+-----------------------
 
 This repo rebuilds the colorschemes every week, so make sure to pull to
 keep up to date with the latest changes.
@@ -36,16 +39,14 @@ keep up to date with the latest changes.
 If you're you're looking to build the colorschemes manually to test out
 a change:
 
-1. Install [base16-builder-go](https://github.com/tinted-theming/base16-builder-go)
-   or a compatible tool.
-   (Note that in the case of `base16-builder-go`
-   the [releases' page](https://github.com/tinted-theming/base16-builder-go/releases)
-   contains pre-built binaries that can be simply downloaded and executed).
-2. Execute the `builder` binary from the `base16-putty` directory.
-   In the case of `base16-builder-go` no argument is required.
+1. Install [builder-go] or a compatible tool. (Note that in the case of
+   `builder-go` the [releases' page] contains pre-built binaries
+   that can be simply downloaded and executed).
+2. Execute the `builder` binary from the `tinted-putty` directory.
+   In the case of `builder-go` no argument is required.
 3. Check if updates took place (new/modified files are placed inside the `/putty` directory).
 
-Have a look at [these guides](https://opensource.guide/how-to-contribute/) for more information.
+Have a look at [these guides] for more information.
 
 Thanks
 ------
@@ -53,3 +54,13 @@ Thanks
 - @staticaland for the [original material](https://github.com/staticaland/base16-putty);
 - @iamthad and @ticky for [mapping](https://github.com/iamthad/base16-mintty) `base16` vars into color names used by PuTTY;
 - @chriskempson for the original conception of the [tinted-theming](https://github.com/tinted-theming/home).
+
+[Base16]: https://github.com/tinted-theming/home
+[Base24]: https://github.com/tinted-theming/base24
+[PuTTY]: https://en.wikipedia.org/wiki/PuTTY
+[base16-gallery]: https://tinted-theming.github.io/base16-gallery/
+[configured]: https://web.archive.org/web/20140803065929/http://www.grok2.com/blog/2013/12/01/putty-linux-terminal-xterm-emacs-256-colors/
+[provide]: https://sanctum.geek.nz/arabesque/putty-configuration/
+[these guides]: https://opensource.guide/how-to-contribute/
+[builder-go]: https://github.com/tinted-theming/base16-builder-go
+[releases' page]: https://github.com/tinted-theming/base16-builder-go/releases

--- a/putty/base16-3024.reg
+++ b/putty/base16-3024.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 3024
+; Scheme name: 3024
+; Scheme system: base16
 ; Scheme author: Jan T. Sott (http://github.com/idleberg)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\3024]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-3024]
 
 ; Default Foreground
 ; base05 #a5a2a2

--- a/putty/base16-apathy.reg
+++ b/putty/base16-apathy.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Apathy
+; Scheme name: Apathy
+; Scheme system: base16
 ; Scheme author: Jannik Siebert (https://github.com/janniks)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\apathy]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-apathy]
 
 ; Default Foreground
 ; base05 #81b5ac

--- a/putty/base16-apprentice.reg
+++ b/putty/base16-apprentice.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Apprentice
+; Scheme name: Apprentice
+; Scheme system: base16
 ; Scheme author: romainl
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\apprentice]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-apprentice]
 
 ; Default Foreground
 ; base05 #5f5f87

--- a/putty/base16-ashes.reg
+++ b/putty/base16-ashes.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Ashes
+; Scheme name: Ashes
+; Scheme system: base16
 ; Scheme author: Jannik Siebert (https://github.com/janniks)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\ashes]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-ashes]
 
 ; Default Foreground
 ; base05 #c7ccd1

--- a/putty/base16-atelier-cave-light.reg
+++ b/putty/base16-atelier-cave-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Cave Light
+; Scheme name: Atelier Cave Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-cave-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-cave-light]
 
 ; Default Foreground
 ; base05 #585260

--- a/putty/base16-atelier-cave.reg
+++ b/putty/base16-atelier-cave.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Cave
+; Scheme name: Atelier Cave
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-cave]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-cave]
 
 ; Default Foreground
 ; base05 #8b8792

--- a/putty/base16-atelier-dune-light.reg
+++ b/putty/base16-atelier-dune-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Dune Light
+; Scheme name: Atelier Dune Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-dune-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-dune-light]
 
 ; Default Foreground
 ; base05 #6e6b5e

--- a/putty/base16-atelier-dune.reg
+++ b/putty/base16-atelier-dune.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Dune
+; Scheme name: Atelier Dune
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-dune]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-dune]
 
 ; Default Foreground
 ; base05 #a6a28c

--- a/putty/base16-atelier-estuary-light.reg
+++ b/putty/base16-atelier-estuary-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Estuary Light
+; Scheme name: Atelier Estuary Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-estuary-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-estuary-light]
 
 ; Default Foreground
 ; base05 #5f5e4e

--- a/putty/base16-atelier-estuary.reg
+++ b/putty/base16-atelier-estuary.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Estuary
+; Scheme name: Atelier Estuary
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-estuary]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-estuary]
 
 ; Default Foreground
 ; base05 #929181

--- a/putty/base16-atelier-forest-light.reg
+++ b/putty/base16-atelier-forest-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Forest Light
+; Scheme name: Atelier Forest Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-forest-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-forest-light]
 
 ; Default Foreground
 ; base05 #68615e

--- a/putty/base16-atelier-forest.reg
+++ b/putty/base16-atelier-forest.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Forest
+; Scheme name: Atelier Forest
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-forest]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-forest]
 
 ; Default Foreground
 ; base05 #a8a19f

--- a/putty/base16-atelier-heath-light.reg
+++ b/putty/base16-atelier-heath-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Heath Light
+; Scheme name: Atelier Heath Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-heath-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-heath-light]
 
 ; Default Foreground
 ; base05 #695d69

--- a/putty/base16-atelier-heath.reg
+++ b/putty/base16-atelier-heath.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Heath
+; Scheme name: Atelier Heath
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-heath]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-heath]
 
 ; Default Foreground
 ; base05 #ab9bab

--- a/putty/base16-atelier-lakeside-light.reg
+++ b/putty/base16-atelier-lakeside-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Lakeside Light
+; Scheme name: Atelier Lakeside Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-lakeside-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-lakeside-light]
 
 ; Default Foreground
 ; base05 #516d7b

--- a/putty/base16-atelier-lakeside.reg
+++ b/putty/base16-atelier-lakeside.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Lakeside
+; Scheme name: Atelier Lakeside
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-lakeside]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-lakeside]
 
 ; Default Foreground
 ; base05 #7ea2b4

--- a/putty/base16-atelier-plateau-light.reg
+++ b/putty/base16-atelier-plateau-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Plateau Light
+; Scheme name: Atelier Plateau Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-plateau-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-plateau-light]
 
 ; Default Foreground
 ; base05 #585050

--- a/putty/base16-atelier-plateau.reg
+++ b/putty/base16-atelier-plateau.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Plateau
+; Scheme name: Atelier Plateau
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-plateau]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-plateau]
 
 ; Default Foreground
 ; base05 #8a8585

--- a/putty/base16-atelier-savanna-light.reg
+++ b/putty/base16-atelier-savanna-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Savanna Light
+; Scheme name: Atelier Savanna Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-savanna-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-savanna-light]
 
 ; Default Foreground
 ; base05 #526057

--- a/putty/base16-atelier-savanna.reg
+++ b/putty/base16-atelier-savanna.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Savanna
+; Scheme name: Atelier Savanna
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-savanna]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-savanna]
 
 ; Default Foreground
 ; base05 #87928a

--- a/putty/base16-atelier-seaside-light.reg
+++ b/putty/base16-atelier-seaside-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Seaside Light
+; Scheme name: Atelier Seaside Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-seaside-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-seaside-light]
 
 ; Default Foreground
 ; base05 #5e6e5e

--- a/putty/base16-atelier-seaside.reg
+++ b/putty/base16-atelier-seaside.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Seaside
+; Scheme name: Atelier Seaside
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-seaside]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-seaside]
 
 ; Default Foreground
 ; base05 #8ca68c

--- a/putty/base16-atelier-sulphurpool-light.reg
+++ b/putty/base16-atelier-sulphurpool-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Sulphurpool Light
+; Scheme name: Atelier Sulphurpool Light
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-sulphurpool-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-sulphurpool-light]
 
 ; Default Foreground
 ; base05 #5e6687

--- a/putty/base16-atelier-sulphurpool.reg
+++ b/putty/base16-atelier-sulphurpool.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atelier Sulphurpool
+; Scheme name: Atelier Sulphurpool
+; Scheme system: base16
 ; Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atelier-sulphurpool]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atelier-sulphurpool]
 
 ; Default Foreground
 ; base05 #979db4

--- a/putty/base16-atlas.reg
+++ b/putty/base16-atlas.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Atlas
+; Scheme name: Atlas
+; Scheme system: base16
 ; Scheme author: Alex Lende (https://ajlende.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\atlas]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-atlas]
 
 ; Default Foreground
 ; base05 #a1a19a

--- a/putty/base16-ayu-dark.reg
+++ b/putty/base16-ayu-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Ayu Dark
+; Scheme name: Ayu Dark
+; Scheme system: base16
 ; Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\ayu-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-ayu-dark]
 
 ; Default Foreground
 ; base05 #e6e1cf

--- a/putty/base16-ayu-light.reg
+++ b/putty/base16-ayu-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Ayu Light
+; Scheme name: Ayu Light
+; Scheme system: base16
 ; Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\ayu-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-ayu-light]
 
 ; Default Foreground
 ; base05 #5c6773

--- a/putty/base16-ayu-mirage.reg
+++ b/putty/base16-ayu-mirage.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Ayu Mirage
+; Scheme name: Ayu Mirage
+; Scheme system: base16
 ; Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\ayu-mirage]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-ayu-mirage]
 
 ; Default Foreground
 ; base05 #cccac2

--- a/putty/base16-bespin.reg
+++ b/putty/base16-bespin.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Bespin
+; Scheme name: Bespin
+; Scheme system: base16
 ; Scheme author: Jan T. Sott
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\bespin]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-bespin]
 
 ; Default Foreground
 ; base05 #8a8986

--- a/putty/base16-black-metal-bathory.reg
+++ b/putty/base16-black-metal-bathory.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Bathory)
+; Scheme name: Black Metal (Bathory)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-bathory]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-bathory]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-burzum.reg
+++ b/putty/base16-black-metal-burzum.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Burzum)
+; Scheme name: Black Metal (Burzum)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-burzum]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-burzum]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-dark-funeral.reg
+++ b/putty/base16-black-metal-dark-funeral.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Dark Funeral)
+; Scheme name: Black Metal (Dark Funeral)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-dark-funeral]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-dark-funeral]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-gorgoroth.reg
+++ b/putty/base16-black-metal-gorgoroth.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Gorgoroth)
+; Scheme name: Black Metal (Gorgoroth)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-gorgoroth]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-gorgoroth]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-immortal.reg
+++ b/putty/base16-black-metal-immortal.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Immortal)
+; Scheme name: Black Metal (Immortal)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-immortal]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-immortal]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-khold.reg
+++ b/putty/base16-black-metal-khold.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Khold)
+; Scheme name: Black Metal (Khold)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-khold]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-khold]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-marduk.reg
+++ b/putty/base16-black-metal-marduk.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Marduk)
+; Scheme name: Black Metal (Marduk)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-marduk]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-marduk]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-mayhem.reg
+++ b/putty/base16-black-metal-mayhem.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Mayhem)
+; Scheme name: Black Metal (Mayhem)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-mayhem]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-mayhem]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-nile.reg
+++ b/putty/base16-black-metal-nile.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Nile)
+; Scheme name: Black Metal (Nile)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-nile]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-nile]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal-venom.reg
+++ b/putty/base16-black-metal-venom.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal (Venom)
+; Scheme name: Black Metal (Venom)
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal-venom]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal-venom]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-black-metal.reg
+++ b/putty/base16-black-metal.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Black Metal
+; Scheme name: Black Metal
+; Scheme system: base16
 ; Scheme author: metalelf0 (https://github.com/metalelf0)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\black-metal]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-black-metal]
 
 ; Default Foreground
 ; base05 #c1c1c1

--- a/putty/base16-blueforest.reg
+++ b/putty/base16-blueforest.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Blue Forest
+; Scheme name: Blue Forest
+; Scheme system: base16
 ; Scheme author: alonsodomin (https://github.com/alonsodomin)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\blueforest]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-blueforest]
 
 ; Default Foreground
 ; base05 #ffcc33

--- a/putty/base16-blueish.reg
+++ b/putty/base16-blueish.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Blueish
+; Scheme name: Blueish
+; Scheme system: base16
 ; Scheme author: Ben Mayoras
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\blueish]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-blueish]
 
 ; Default Foreground
 ; base05 #c8e1f8

--- a/putty/base16-brewer.reg
+++ b/putty/base16-brewer.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Brewer
+; Scheme name: Brewer
+; Scheme system: base16
 ; Scheme author: Timothée Poisot (http://github.com/tpoisot)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\brewer]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-brewer]
 
 ; Default Foreground
 ; base05 #b7b8b9

--- a/putty/base16-bright.reg
+++ b/putty/base16-bright.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Bright
+; Scheme name: Bright
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\bright]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-bright]
 
 ; Default Foreground
 ; base05 #e0e0e0

--- a/putty/base16-brogrammer.reg
+++ b/putty/base16-brogrammer.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Brogrammer
+; Scheme name: Brogrammer
+; Scheme system: base16
 ; Scheme author: Vik Ramanujam (http://github.com/piggyslasher)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\brogrammer]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-brogrammer]
 
 ; Default Foreground
 ; base05 #4e5ab7

--- a/putty/base16-brushtrees-dark.reg
+++ b/putty/base16-brushtrees-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Brush Trees Dark
+; Scheme name: Brush Trees Dark
+; Scheme system: base16
 ; Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\brushtrees-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-brushtrees-dark]
 
 ; Default Foreground
 ; base05 #b0c5c8

--- a/putty/base16-brushtrees.reg
+++ b/putty/base16-brushtrees.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Brush Trees
+; Scheme name: Brush Trees
+; Scheme system: base16
 ; Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\brushtrees]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-brushtrees]
 
 ; Default Foreground
 ; base05 #6d828e

--- a/putty/base16-caroline.reg
+++ b/putty/base16-caroline.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 caroline
+; Scheme name: caroline
+; Scheme system: base16
 ; Scheme author: ed (https://codeberg.org/ed)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\caroline]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-caroline]
 
 ; Default Foreground
 ; base05 #a87569

--- a/putty/base16-catppuccin-frappe.reg
+++ b/putty/base16-catppuccin-frappe.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Catppuccin Frappe
+; Scheme name: Catppuccin Frappe
+; Scheme system: base16
 ; Scheme author: https://github.com/catppuccin/catppuccin
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\catppuccin-frappe]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-catppuccin-frappe]
 
 ; Default Foreground
 ; base05 #c6d0f5

--- a/putty/base16-catppuccin-latte.reg
+++ b/putty/base16-catppuccin-latte.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Catppuccin Latte
+; Scheme name: Catppuccin Latte
+; Scheme system: base16
 ; Scheme author: https://github.com/catppuccin/catppuccin
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\catppuccin-latte]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-catppuccin-latte]
 
 ; Default Foreground
 ; base05 #4c4f69

--- a/putty/base16-catppuccin-macchiato.reg
+++ b/putty/base16-catppuccin-macchiato.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Catppuccin Macchiato
+; Scheme name: Catppuccin Macchiato
+; Scheme system: base16
 ; Scheme author: https://github.com/catppuccin/catppuccin
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\catppuccin-macchiato]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-catppuccin-macchiato]
 
 ; Default Foreground
 ; base05 #cad3f5

--- a/putty/base16-catppuccin-mocha.reg
+++ b/putty/base16-catppuccin-mocha.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Catppuccin Mocha
+; Scheme name: Catppuccin Mocha
+; Scheme system: base16
 ; Scheme author: https://github.com/catppuccin/catppuccin
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\catppuccin-mocha]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-catppuccin-mocha]
 
 ; Default Foreground
 ; base05 #cdd6f4

--- a/putty/base16-chalk.reg
+++ b/putty/base16-chalk.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Chalk
+; Scheme name: Chalk
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\chalk]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-chalk]
 
 ; Default Foreground
 ; base05 #d0d0d0

--- a/putty/base16-circus.reg
+++ b/putty/base16-circus.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Circus
+; Scheme name: Circus
+; Scheme system: base16
 ; Scheme author: Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\circus]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-circus]
 
 ; Default Foreground
 ; base05 #a7a7a7

--- a/putty/base16-classic-dark.reg
+++ b/putty/base16-classic-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Classic Dark
+; Scheme name: Classic Dark
+; Scheme system: base16
 ; Scheme author: Jason Heeris (http://heeris.id.au)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\classic-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-classic-dark]
 
 ; Default Foreground
 ; base05 #d0d0d0

--- a/putty/base16-classic-light.reg
+++ b/putty/base16-classic-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Classic Light
+; Scheme name: Classic Light
+; Scheme system: base16
 ; Scheme author: Jason Heeris (http://heeris.id.au)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\classic-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-classic-light]
 
 ; Default Foreground
 ; base05 #303030

--- a/putty/base16-codeschool.reg
+++ b/putty/base16-codeschool.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Codeschool
+; Scheme name: Codeschool
+; Scheme system: base16
 ; Scheme author: blockloop
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\codeschool]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-codeschool]
 
 ; Default Foreground
 ; base05 #9ea7a6

--- a/putty/base16-colors.reg
+++ b/putty/base16-colors.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Colors
+; Scheme name: Colors
+; Scheme system: base16
 ; Scheme author: mrmrs (http://clrs.cc)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\colors]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-colors]
 
 ; Default Foreground
 ; base05 #bbbbbb

--- a/putty/base16-cupcake.reg
+++ b/putty/base16-cupcake.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Cupcake
+; Scheme name: Cupcake
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\cupcake]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-cupcake]
 
 ; Default Foreground
 ; base05 #8b8198

--- a/putty/base16-cupertino.reg
+++ b/putty/base16-cupertino.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Cupertino
+; Scheme name: Cupertino
+; Scheme system: base16
 ; Scheme author: Defman21
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\cupertino]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-cupertino]
 
 ; Default Foreground
 ; base05 #404040

--- a/putty/base16-da-one-black.reg
+++ b/putty/base16-da-one-black.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Da One Black
+; Scheme name: Da One Black
+; Scheme system: base16
 ; Scheme author: NNB (https://github.com/NNBnh)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\da-one-black]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-da-one-black]
 
 ; Default Foreground
 ; base05 #ffffff

--- a/putty/base16-da-one-gray.reg
+++ b/putty/base16-da-one-gray.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Da One Gray
+; Scheme name: Da One Gray
+; Scheme system: base16
 ; Scheme author: NNB (https://github.com/NNBnh)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\da-one-gray]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-da-one-gray]
 
 ; Default Foreground
 ; base05 #ffffff

--- a/putty/base16-da-one-ocean.reg
+++ b/putty/base16-da-one-ocean.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Da One Ocean
+; Scheme name: Da One Ocean
+; Scheme system: base16
 ; Scheme author: NNB (https://github.com/NNBnh)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\da-one-ocean]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-da-one-ocean]
 
 ; Default Foreground
 ; base05 #ffffff

--- a/putty/base16-da-one-paper.reg
+++ b/putty/base16-da-one-paper.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Da One Paper
+; Scheme name: Da One Paper
+; Scheme system: base16
 ; Scheme author: NNB (https://github.com/NNBnh)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\da-one-paper]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-da-one-paper]
 
 ; Default Foreground
 ; base05 #181818

--- a/putty/base16-da-one-sea.reg
+++ b/putty/base16-da-one-sea.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Da One Sea
+; Scheme name: Da One Sea
+; Scheme system: base16
 ; Scheme author: NNB (https://github.com/NNBnh)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\da-one-sea]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-da-one-sea]
 
 ; Default Foreground
 ; base05 #ffffff

--- a/putty/base16-da-one-white.reg
+++ b/putty/base16-da-one-white.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Da One White
+; Scheme name: Da One White
+; Scheme system: base16
 ; Scheme author: NNB (https://github.com/NNBnh)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\da-one-white]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-da-one-white]
 
 ; Default Foreground
 ; base05 #181818

--- a/putty/base16-danqing-light.reg
+++ b/putty/base16-danqing-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 DanQing Light
+; Scheme name: DanQing Light
+; Scheme system: base16
 ; Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\danqing-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-danqing-light]
 
 ; Default Foreground
 ; base05 #5a605d

--- a/putty/base16-danqing.reg
+++ b/putty/base16-danqing.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 DanQing
+; Scheme name: DanQing
+; Scheme system: base16
 ; Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\danqing]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-danqing]
 
 ; Default Foreground
 ; base05 #e0f0ef

--- a/putty/base16-darcula.reg
+++ b/putty/base16-darcula.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Darcula
+; Scheme name: Darcula
+; Scheme system: base16
 ; Scheme author: jetbrains
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\darcula]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-darcula]
 
 ; Default Foreground
 ; base05 #a9b7c6

--- a/putty/base16-darkmoss.reg
+++ b/putty/base16-darkmoss.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 darkmoss
+; Scheme name: darkmoss
+; Scheme system: base16
 ; Scheme author: Gabriel Avanzi (https://github.com/avanzzzi)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\darkmoss]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-darkmoss]
 
 ; Default Foreground
 ; base05 #c7c7a5

--- a/putty/base16-darktooth.reg
+++ b/putty/base16-darktooth.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Darktooth
+; Scheme name: Darktooth
+; Scheme system: base16
 ; Scheme author: Jason Milkins (https://github.com/jasonm23)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\darktooth]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-darktooth]
 
 ; Default Foreground
 ; base05 #a89984

--- a/putty/base16-darkviolet.reg
+++ b/putty/base16-darkviolet.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Dark Violet
+; Scheme name: Dark Violet
+; Scheme system: base16
 ; Scheme author: ruler501 (https://github.com/ruler501/base16-darkviolet)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\darkviolet]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-darkviolet]
 
 ; Default Foreground
 ; base05 #b08ae6

--- a/putty/base16-decaf.reg
+++ b/putty/base16-decaf.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Decaf
+; Scheme name: Decaf
+; Scheme system: base16
 ; Scheme author: Alex Mirrington (https://github.com/alexmirrington)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\decaf]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-decaf]
 
 ; Default Foreground
 ; base05 #cccccc

--- a/putty/base16-default-dark.reg
+++ b/putty/base16-default-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Default Dark
+; Scheme name: Default Dark
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\default-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-default-dark]
 
 ; Default Foreground
 ; base05 #d8d8d8

--- a/putty/base16-default-light.reg
+++ b/putty/base16-default-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Default Light
+; Scheme name: Default Light
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\default-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-default-light]
 
 ; Default Foreground
 ; base05 #383838

--- a/putty/base16-dirtysea.reg
+++ b/putty/base16-dirtysea.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 dirtysea
+; Scheme name: dirtysea
+; Scheme system: base16
 ; Scheme author: Kahlil (Kal) Hodgson
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\dirtysea]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-dirtysea]
 
 ; Default Foreground
 ; base05 #000000

--- a/putty/base16-dracula.reg
+++ b/putty/base16-dracula.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Dracula
+; Scheme name: Dracula
+; Scheme system: base16
 ; Scheme author: Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\dracula]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-dracula]
 
 ; Default Foreground
 ; base05 #e9e9f4

--- a/putty/base16-edge-dark.reg
+++ b/putty/base16-edge-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Edge Dark
+; Scheme name: Edge Dark
+; Scheme system: base16
 ; Scheme author: cjayross (https://github.com/cjayross)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\edge-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-edge-dark]
 
 ; Default Foreground
 ; base05 #b7bec9

--- a/putty/base16-edge-light.reg
+++ b/putty/base16-edge-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Edge Light
+; Scheme name: Edge Light
+; Scheme system: base16
 ; Scheme author: cjayross (https://github.com/cjayross)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\edge-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-edge-light]
 
 ; Default Foreground
 ; base05 #5e646f

--- a/putty/base16-eighties.reg
+++ b/putty/base16-eighties.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Eighties
+; Scheme name: Eighties
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\eighties]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-eighties]
 
 ; Default Foreground
 ; base05 #d3d0c8

--- a/putty/base16-embers-light.reg
+++ b/putty/base16-embers-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Embers Light
+; Scheme name: Embers Light
+; Scheme system: base16
 ; Scheme author: Jannik Siebert (https://github.com/janniks)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\embers-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-embers-light]
 
 ; Default Foreground
 ; base05 #323b43

--- a/putty/base16-embers.reg
+++ b/putty/base16-embers.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Embers
+; Scheme name: Embers
+; Scheme system: base16
 ; Scheme author: Jannik Siebert (https://github.com/janniks)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\embers]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-embers]
 
 ; Default Foreground
 ; base05 #a39a90

--- a/putty/base16-emil.reg
+++ b/putty/base16-emil.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 emil
+; Scheme name: emil
+; Scheme system: base16
 ; Scheme author: limelier
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\emil]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-emil]
 
 ; Default Foreground
 ; base05 #313145

--- a/putty/base16-equilibrium-dark.reg
+++ b/putty/base16-equilibrium-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Equilibrium Dark
+; Scheme name: Equilibrium Dark
+; Scheme system: base16
 ; Scheme author: Carlo Abelli
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\equilibrium-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-equilibrium-dark]
 
 ; Default Foreground
 ; base05 #afaba2

--- a/putty/base16-equilibrium-gray-dark.reg
+++ b/putty/base16-equilibrium-gray-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Equilibrium Gray Dark
+; Scheme name: Equilibrium Gray Dark
+; Scheme system: base16
 ; Scheme author: Carlo Abelli
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\equilibrium-gray-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-equilibrium-gray-dark]
 
 ; Default Foreground
 ; base05 #ababab

--- a/putty/base16-equilibrium-gray-light.reg
+++ b/putty/base16-equilibrium-gray-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Equilibrium Gray Light
+; Scheme name: Equilibrium Gray Light
+; Scheme system: base16
 ; Scheme author: Carlo Abelli
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\equilibrium-gray-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-equilibrium-gray-light]
 
 ; Default Foreground
 ; base05 #474747

--- a/putty/base16-equilibrium-light.reg
+++ b/putty/base16-equilibrium-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Equilibrium Light
+; Scheme name: Equilibrium Light
+; Scheme system: base16
 ; Scheme author: Carlo Abelli
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\equilibrium-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-equilibrium-light]
 
 ; Default Foreground
 ; base05 #43474e

--- a/putty/base16-eris.reg
+++ b/putty/base16-eris.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 eris
+; Scheme name: eris
+; Scheme system: base16
 ; Scheme author: ed (https://codeberg.org/ed)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\eris]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-eris]
 
 ; Default Foreground
 ; base05 #606bac

--- a/putty/base16-espresso.reg
+++ b/putty/base16-espresso.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Espresso
+; Scheme name: Espresso
+; Scheme system: base16
 ; Scheme author: Unknown. Maintained by Alex Mirrington (https://github.com/alexmirrington)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\espresso]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-espresso]
 
 ; Default Foreground
 ; base05 #cccccc

--- a/putty/base16-eva-dim.reg
+++ b/putty/base16-eva-dim.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Eva Dim
+; Scheme name: Eva Dim
+; Scheme system: base16
 ; Scheme author: kjakapat (https://github.com/kjakapat)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\eva-dim]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-eva-dim]
 
 ; Default Foreground
 ; base05 #9fa2a6

--- a/putty/base16-eva.reg
+++ b/putty/base16-eva.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Eva
+; Scheme name: Eva
+; Scheme system: base16
 ; Scheme author: kjakapat (https://github.com/kjakapat)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\eva]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-eva]
 
 ; Default Foreground
 ; base05 #9fa2a6

--- a/putty/base16-evenok-dark.reg
+++ b/putty/base16-evenok-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Evenok Dark
+; Scheme name: Evenok Dark
+; Scheme system: base16
 ; Scheme author: Mekeor Melire
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\evenok-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-evenok-dark]
 
 ; Default Foreground
 ; base05 #d0d0d0

--- a/putty/base16-everforest-dark-hard.reg
+++ b/putty/base16-everforest-dark-hard.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Everforest Dark Hard
+; Scheme name: Everforest Dark Hard
+; Scheme system: base16
 ; Scheme author: Oskar Liew (https://github.com/OskarLiew)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\everforest-dark-hard]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-everforest-dark-hard]
 
 ; Default Foreground
 ; base05 #d3c6aa

--- a/putty/base16-everforest.reg
+++ b/putty/base16-everforest.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Everforest
+; Scheme name: Everforest
+; Scheme system: base16
 ; Scheme author: Sainnhe Park (https://github.com/sainnhe)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\everforest]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-everforest]
 
 ; Default Foreground
 ; base05 #d3c6aa

--- a/putty/base16-flat.reg
+++ b/putty/base16-flat.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Flat
+; Scheme name: Flat
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\flat]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-flat]
 
 ; Default Foreground
 ; base05 #e0e0e0

--- a/putty/base16-framer.reg
+++ b/putty/base16-framer.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Framer
+; Scheme name: Framer
+; Scheme system: base16
 ; Scheme author: Framer (Maintained by Jesse Hoyos)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\framer]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-framer]
 
 ; Default Foreground
 ; base05 #d0d0d0

--- a/putty/base16-fruit-soda.reg
+++ b/putty/base16-fruit-soda.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Fruit Soda
+; Scheme name: Fruit Soda
+; Scheme system: base16
 ; Scheme author: jozip
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\fruit-soda]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-fruit-soda]
 
 ; Default Foreground
 ; base05 #515151

--- a/putty/base16-gigavolt.reg
+++ b/putty/base16-gigavolt.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gigavolt
+; Scheme name: Gigavolt
+; Scheme system: base16
 ; Scheme author: Aidan Swope (http://github.com/Whillikers)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gigavolt]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gigavolt]
 
 ; Default Foreground
 ; base05 #e9e7e1

--- a/putty/base16-github.reg
+++ b/putty/base16-github.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Github
+; Scheme name: Github
+; Scheme system: base16
 ; Scheme author: Defman21
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\github]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-github]
 
 ; Default Foreground
 ; base05 #333333

--- a/putty/base16-google-dark.reg
+++ b/putty/base16-google-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Google Dark
+; Scheme name: Google Dark
+; Scheme system: base16
 ; Scheme author: Seth Wright (http://sethawright.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\google-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-google-dark]
 
 ; Default Foreground
 ; base05 #c5c8c6

--- a/putty/base16-google-light.reg
+++ b/putty/base16-google-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Google Light
+; Scheme name: Google Light
+; Scheme system: base16
 ; Scheme author: Seth Wright (http://sethawright.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\google-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-google-light]
 
 ; Default Foreground
 ; base05 #373b41

--- a/putty/base16-gotham.reg
+++ b/putty/base16-gotham.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gotham
+; Scheme name: Gotham
+; Scheme system: base16
 ; Scheme author: Andrea Leopardi (arranged by Brett Jones)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gotham]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gotham]
 
 ; Default Foreground
 ; base05 #599cab

--- a/putty/base16-grayscale-dark.reg
+++ b/putty/base16-grayscale-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Grayscale Dark
+; Scheme name: Grayscale Dark
+; Scheme system: base16
 ; Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\grayscale-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-grayscale-dark]
 
 ; Default Foreground
 ; base05 #b9b9b9

--- a/putty/base16-grayscale-light.reg
+++ b/putty/base16-grayscale-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Grayscale Light
+; Scheme name: Grayscale Light
+; Scheme system: base16
 ; Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\grayscale-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-grayscale-light]
 
 ; Default Foreground
 ; base05 #464646

--- a/putty/base16-greenscreen.reg
+++ b/putty/base16-greenscreen.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Green Screen
+; Scheme name: Green Screen
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\greenscreen]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-greenscreen]
 
 ; Default Foreground
 ; base05 #00bb00

--- a/putty/base16-gruber.reg
+++ b/putty/base16-gruber.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruber
+; Scheme name: Gruber
+; Scheme system: base16
 ; Scheme author: Patel, Nimai &lt;nimai.m.patel@gmail.com&gt;, colors from www.github.com/rexim/gruber-darker-theme
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruber]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruber]
 
 ; Default Foreground
 ; base05 #f4f4ff

--- a/putty/base16-gruvbox-dark-hard.reg
+++ b/putty/base16-gruvbox-dark-hard.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox dark, hard
+; Scheme name: Gruvbox dark, hard
+; Scheme system: base16
 ; Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-dark-hard]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-dark-hard]
 
 ; Default Foreground
 ; base05 #d5c4a1

--- a/putty/base16-gruvbox-dark-medium.reg
+++ b/putty/base16-gruvbox-dark-medium.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox dark, medium
+; Scheme name: Gruvbox dark, medium
+; Scheme system: base16
 ; Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-dark-medium]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-dark-medium]
 
 ; Default Foreground
 ; base05 #d5c4a1

--- a/putty/base16-gruvbox-dark-pale.reg
+++ b/putty/base16-gruvbox-dark-pale.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox dark, pale
+; Scheme name: Gruvbox dark, pale
+; Scheme system: base16
 ; Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-dark-pale]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-dark-pale]
 
 ; Default Foreground
 ; base05 #dab997

--- a/putty/base16-gruvbox-dark-soft.reg
+++ b/putty/base16-gruvbox-dark-soft.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox dark, soft
+; Scheme name: Gruvbox dark, soft
+; Scheme system: base16
 ; Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-dark-soft]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-dark-soft]
 
 ; Default Foreground
 ; base05 #d5c4a1

--- a/putty/base16-gruvbox-light-hard.reg
+++ b/putty/base16-gruvbox-light-hard.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox light, hard
+; Scheme name: Gruvbox light, hard
+; Scheme system: base16
 ; Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-light-hard]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-light-hard]
 
 ; Default Foreground
 ; base05 #504945

--- a/putty/base16-gruvbox-light-medium.reg
+++ b/putty/base16-gruvbox-light-medium.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox light, medium
+; Scheme name: Gruvbox light, medium
+; Scheme system: base16
 ; Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-light-medium]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-light-medium]
 
 ; Default Foreground
 ; base05 #504945

--- a/putty/base16-gruvbox-light-soft.reg
+++ b/putty/base16-gruvbox-light-soft.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox light, soft
+; Scheme name: Gruvbox light, soft
+; Scheme system: base16
 ; Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-light-soft]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-light-soft]
 
 ; Default Foreground
 ; base05 #504945

--- a/putty/base16-gruvbox-material-dark-hard.reg
+++ b/putty/base16-gruvbox-material-dark-hard.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox Material Dark, Hard
+; Scheme name: Gruvbox Material Dark, Hard
+; Scheme system: base16
 ; Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-material-dark-hard]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-material-dark-hard]
 
 ; Default Foreground
 ; base05 #ddc7a1

--- a/putty/base16-gruvbox-material-dark-medium.reg
+++ b/putty/base16-gruvbox-material-dark-medium.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox Material Dark, Medium
+; Scheme name: Gruvbox Material Dark, Medium
+; Scheme system: base16
 ; Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-material-dark-medium]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-material-dark-medium]
 
 ; Default Foreground
 ; base05 #ddc7a1

--- a/putty/base16-gruvbox-material-dark-soft.reg
+++ b/putty/base16-gruvbox-material-dark-soft.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox Material Dark, Soft
+; Scheme name: Gruvbox Material Dark, Soft
+; Scheme system: base16
 ; Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-material-dark-soft]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-material-dark-soft]
 
 ; Default Foreground
 ; base05 #ddc7a1

--- a/putty/base16-gruvbox-material-light-hard.reg
+++ b/putty/base16-gruvbox-material-light-hard.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox Material Light, Hard
+; Scheme name: Gruvbox Material Light, Hard
+; Scheme system: base16
 ; Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-material-light-hard]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-material-light-hard]
 
 ; Default Foreground
 ; base05 #654735

--- a/putty/base16-gruvbox-material-light-medium.reg
+++ b/putty/base16-gruvbox-material-light-medium.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox Material Light, Medium
+; Scheme name: Gruvbox Material Light, Medium
+; Scheme system: base16
 ; Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-material-light-medium]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-material-light-medium]
 
 ; Default Foreground
 ; base05 #654735

--- a/putty/base16-gruvbox-material-light-soft.reg
+++ b/putty/base16-gruvbox-material-light-soft.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Gruvbox Material Light, Soft
+; Scheme name: Gruvbox Material Light, Soft
+; Scheme system: base16
 ; Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\gruvbox-material-light-soft]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-gruvbox-material-light-soft]
 
 ; Default Foreground
 ; base05 #654735

--- a/putty/base16-hardcore.reg
+++ b/putty/base16-hardcore.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Hardcore
+; Scheme name: Hardcore
+; Scheme system: base16
 ; Scheme author: Chris Caller
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\hardcore]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-hardcore]
 
 ; Default Foreground
 ; base05 #cdcdcd

--- a/putty/base16-harmonic16-dark.reg
+++ b/putty/base16-harmonic16-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Harmonic16 Dark
+; Scheme name: Harmonic16 Dark
+; Scheme system: base16
 ; Scheme author: Jannik Siebert (https://github.com/janniks)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\harmonic16-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-harmonic16-dark]
 
 ; Default Foreground
 ; base05 #cbd6e2

--- a/putty/base16-harmonic16-light.reg
+++ b/putty/base16-harmonic16-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Harmonic16 Light
+; Scheme name: Harmonic16 Light
+; Scheme system: base16
 ; Scheme author: Jannik Siebert (https://github.com/janniks)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\harmonic16-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-harmonic16-light]
 
 ; Default Foreground
 ; base05 #405c79

--- a/putty/base16-heetch-light.reg
+++ b/putty/base16-heetch-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Heetch Light
+; Scheme name: Heetch Light
+; Scheme system: base16
 ; Scheme author: Geoffrey Teale (tealeg@gmail.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\heetch-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-heetch-light]
 
 ; Default Foreground
 ; base05 #5a496e

--- a/putty/base16-heetch.reg
+++ b/putty/base16-heetch.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Heetch Dark
+; Scheme name: Heetch Dark
+; Scheme system: base16
 ; Scheme author: Geoffrey Teale (tealeg@gmail.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\heetch]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-heetch]
 
 ; Default Foreground
 ; base05 #bdb6c5

--- a/putty/base16-helios.reg
+++ b/putty/base16-helios.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Helios
+; Scheme name: Helios
+; Scheme system: base16
 ; Scheme author: Alex Meyer (https://github.com/reyemxela)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\helios]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-helios]
 
 ; Default Foreground
 ; base05 #d5d5d5

--- a/putty/base16-hopscotch.reg
+++ b/putty/base16-hopscotch.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Hopscotch
+; Scheme name: Hopscotch
+; Scheme system: base16
 ; Scheme author: Jan T. Sott
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\hopscotch]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-hopscotch]
 
 ; Default Foreground
 ; base05 #b9b5b8

--- a/putty/base16-horizon-dark.reg
+++ b/putty/base16-horizon-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Horizon Dark
+; Scheme name: Horizon Dark
+; Scheme system: base16
 ; Scheme author: Michaël Ball (http://github.com/michael-ball/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\horizon-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-horizon-dark]
 
 ; Default Foreground
 ; base05 #cbced0

--- a/putty/base16-horizon-light.reg
+++ b/putty/base16-horizon-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Horizon Light
+; Scheme name: Horizon Light
+; Scheme system: base16
 ; Scheme author: Michaël Ball (http://github.com/michael-ball/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\horizon-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-horizon-light]
 
 ; Default Foreground
 ; base05 #403c3d

--- a/putty/base16-horizon-terminal-dark.reg
+++ b/putty/base16-horizon-terminal-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Horizon Terminal Dark
+; Scheme name: Horizon Terminal Dark
+; Scheme system: base16
 ; Scheme author: Michaël Ball (http://github.com/michael-ball/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\horizon-terminal-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-horizon-terminal-dark]
 
 ; Default Foreground
 ; base05 #cbced0

--- a/putty/base16-horizon-terminal-light.reg
+++ b/putty/base16-horizon-terminal-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Horizon Terminal Light
+; Scheme name: Horizon Terminal Light
+; Scheme system: base16
 ; Scheme author: Michaël Ball (http://github.com/michael-ball/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\horizon-terminal-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-horizon-terminal-light]
 
 ; Default Foreground
 ; base05 #403c3d

--- a/putty/base16-humanoid-dark.reg
+++ b/putty/base16-humanoid-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Humanoid dark
+; Scheme name: Humanoid dark
+; Scheme system: base16
 ; Scheme author: Thomas (tasmo) Friese
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\humanoid-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-humanoid-dark]
 
 ; Default Foreground
 ; base05 #f8f8f2

--- a/putty/base16-humanoid-light.reg
+++ b/putty/base16-humanoid-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Humanoid light
+; Scheme name: Humanoid light
+; Scheme system: base16
 ; Scheme author: Thomas (tasmo) Friese
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\humanoid-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-humanoid-light]
 
 ; Default Foreground
 ; base05 #232629

--- a/putty/base16-ia-dark.reg
+++ b/putty/base16-ia-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 iA Dark
+; Scheme name: iA Dark
+; Scheme system: base16
 ; Scheme author: iA Inc. (modified by aramisgithub)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\ia-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-ia-dark]
 
 ; Default Foreground
 ; base05 #cccccc

--- a/putty/base16-ia-light.reg
+++ b/putty/base16-ia-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 iA Light
+; Scheme name: iA Light
+; Scheme system: base16
 ; Scheme author: iA Inc. (modified by aramisgithub)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\ia-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-ia-light]
 
 ; Default Foreground
 ; base05 #181818

--- a/putty/base16-icy.reg
+++ b/putty/base16-icy.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Icy Dark
+; Scheme name: Icy Dark
+; Scheme system: base16
 ; Scheme author: icyphox (https://icyphox.ga)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\icy]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-icy]
 
 ; Default Foreground
 ; base05 #095b67

--- a/putty/base16-irblack.reg
+++ b/putty/base16-irblack.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 IR Black
+; Scheme name: IR Black
+; Scheme system: base16
 ; Scheme author: Timothée Poisot (http://timotheepoisot.fr)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\irblack]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-irblack]
 
 ; Default Foreground
 ; base05 #b5b3aa

--- a/putty/base16-isotope.reg
+++ b/putty/base16-isotope.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Isotope
+; Scheme name: Isotope
+; Scheme system: base16
 ; Scheme author: Jan T. Sott
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\isotope]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-isotope]
 
 ; Default Foreground
 ; base05 #d0d0d0

--- a/putty/base16-jabuti.reg
+++ b/putty/base16-jabuti.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Jabuti
+; Scheme name: Jabuti
+; Scheme system: base16
 ; Scheme author: https://github.com/notusknot
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\jabuti]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-jabuti]
 
 ; Default Foreground
 ; base05 #c0cbe3

--- a/putty/base16-kanagawa.reg
+++ b/putty/base16-kanagawa.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Kanagawa
+; Scheme name: Kanagawa
+; Scheme system: base16
 ; Scheme author: Tommaso Laurenzi (https://github.com/rebelot)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\kanagawa]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-kanagawa]
 
 ; Default Foreground
 ; base05 #dcd7ba

--- a/putty/base16-katy.reg
+++ b/putty/base16-katy.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Katy
+; Scheme name: Katy
+; Scheme system: base16
 ; Scheme author: George Essig (https://github.com/gessig)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\katy]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-katy]
 
 ; Default Foreground
 ; base05 #959dcb

--- a/putty/base16-kimber.reg
+++ b/putty/base16-kimber.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Kimber
+; Scheme name: Kimber
+; Scheme system: base16
 ; Scheme author: Mishka Nguyen (https://github.com/akhsiM)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\kimber]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-kimber]
 
 ; Default Foreground
 ; base05 #dedee7

--- a/putty/base16-lime.reg
+++ b/putty/base16-lime.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 lime
+; Scheme name: lime
+; Scheme system: base16
 ; Scheme author: limelier
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\lime]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-lime]
 
 ; Default Foreground
 ; base05 #818175

--- a/putty/base16-macintosh.reg
+++ b/putty/base16-macintosh.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Macintosh
+; Scheme name: Macintosh
+; Scheme system: base16
 ; Scheme author: Rebecca Bettencourt (http://www.kreativekorp.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\macintosh]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-macintosh]
 
 ; Default Foreground
 ; base05 #c0c0c0

--- a/putty/base16-marrakesh.reg
+++ b/putty/base16-marrakesh.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Marrakesh
+; Scheme name: Marrakesh
+; Scheme system: base16
 ; Scheme author: Alexandre Gavioli (http://github.com/Alexx2/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\marrakesh]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-marrakesh]
 
 ; Default Foreground
 ; base05 #948e48

--- a/putty/base16-materia.reg
+++ b/putty/base16-materia.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Materia
+; Scheme name: Materia
+; Scheme system: base16
 ; Scheme author: Defman21
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\materia]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-materia]
 
 ; Default Foreground
 ; base05 #cdd3de

--- a/putty/base16-material-darker.reg
+++ b/putty/base16-material-darker.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Material Darker
+; Scheme name: Material Darker
+; Scheme system: base16
 ; Scheme author: Nate Peterson
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\material-darker]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-material-darker]
 
 ; Default Foreground
 ; base05 #eeffff

--- a/putty/base16-material-lighter.reg
+++ b/putty/base16-material-lighter.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Material Lighter
+; Scheme name: Material Lighter
+; Scheme system: base16
 ; Scheme author: Nate Peterson
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\material-lighter]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-material-lighter]
 
 ; Default Foreground
 ; base05 #80cbc4

--- a/putty/base16-material-palenight.reg
+++ b/putty/base16-material-palenight.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Material Palenight
+; Scheme name: Material Palenight
+; Scheme system: base16
 ; Scheme author: Nate Peterson
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\material-palenight]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-material-palenight]
 
 ; Default Foreground
 ; base05 #959dcb

--- a/putty/base16-material-vivid.reg
+++ b/putty/base16-material-vivid.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Material Vivid
+; Scheme name: Material Vivid
+; Scheme system: base16
 ; Scheme author: joshyrobot
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\material-vivid]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-material-vivid]
 
 ; Default Foreground
 ; base05 #80868b

--- a/putty/base16-material.reg
+++ b/putty/base16-material.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Material
+; Scheme name: Material
+; Scheme system: base16
 ; Scheme author: Nate Peterson
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\material]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-material]
 
 ; Default Foreground
 ; base05 #eeffff

--- a/putty/base16-measured-dark.reg
+++ b/putty/base16-measured-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Measured Dark
+; Scheme name: Measured Dark
+; Scheme system: base16
 ; Scheme author: Measured (https://measured.co)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\measured-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-measured-dark]
 
 ; Default Foreground
 ; base05 #dcdcdc

--- a/putty/base16-measured-light.reg
+++ b/putty/base16-measured-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Measured Light
+; Scheme name: Measured Light
+; Scheme system: base16
 ; Scheme author: Measured (https://measured.co)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\measured-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-measured-light]
 
 ; Default Foreground
 ; base05 #292929

--- a/putty/base16-mellow-purple.reg
+++ b/putty/base16-mellow-purple.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Mellow Purple
+; Scheme name: Mellow Purple
+; Scheme system: base16
 ; Scheme author: gidsi
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\mellow-purple]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-mellow-purple]
 
 ; Default Foreground
 ; base05 #ffeeff

--- a/putty/base16-mexico-light.reg
+++ b/putty/base16-mexico-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Mexico Light
+; Scheme name: Mexico Light
+; Scheme system: base16
 ; Scheme author: Sheldon Johnson
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\mexico-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-mexico-light]
 
 ; Default Foreground
 ; base05 #383838

--- a/putty/base16-mocha.reg
+++ b/putty/base16-mocha.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Mocha
+; Scheme name: Mocha
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\mocha]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-mocha]
 
 ; Default Foreground
 ; base05 #d0c8c6

--- a/putty/base16-monokai.reg
+++ b/putty/base16-monokai.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Monokai
+; Scheme name: Monokai
+; Scheme system: base16
 ; Scheme author: Wimer Hazenberg (http://www.monokai.nl)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\monokai]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-monokai]
 
 ; Default Foreground
 ; base05 #f8f8f2

--- a/putty/base16-mountain.reg
+++ b/putty/base16-mountain.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Mountain
+; Scheme name: Mountain
+; Scheme system: base16
 ; Scheme author: gnsfujiwara (https://github.com/gnsfujiwara)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\mountain]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-mountain]
 
 ; Default Foreground
 ; base05 #cacaca

--- a/putty/base16-nebula.reg
+++ b/putty/base16-nebula.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Nebula
+; Scheme name: Nebula
+; Scheme system: base16
 ; Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\nebula]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-nebula]
 
 ; Default Foreground
 ; base05 #a4a6a9

--- a/putty/base16-nord-light.reg
+++ b/putty/base16-nord-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Nord Light
+; Scheme name: Nord Light
+; Scheme system: base16
 ; Scheme author: threddast, based on fuxialexander&#39;s doom-nord-light-theme (Doom Emacs)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\nord-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-nord-light]
 
 ; Default Foreground
 ; base05 #2e3440

--- a/putty/base16-nord.reg
+++ b/putty/base16-nord.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Nord
+; Scheme name: Nord
+; Scheme system: base16
 ; Scheme author: arcticicestudio
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\nord]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-nord]
 
 ; Default Foreground
 ; base05 #e5e9f0

--- a/putty/base16-nova.reg
+++ b/putty/base16-nova.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Nova
+; Scheme name: Nova
+; Scheme system: base16
 ; Scheme author: George Essig (https://github.com/gessig), Trevor D. Miller (https://trevordmiller.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\nova]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-nova]
 
 ; Default Foreground
 ; base05 #c5d4dd

--- a/putty/base16-ocean.reg
+++ b/putty/base16-ocean.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Ocean
+; Scheme name: Ocean
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\ocean]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-ocean]
 
 ; Default Foreground
 ; base05 #c0c5ce

--- a/putty/base16-oceanicnext.reg
+++ b/putty/base16-oceanicnext.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 OceanicNext
+; Scheme name: OceanicNext
+; Scheme system: base16
 ; Scheme author: https://github.com/voronianski/oceanic-next-color-scheme
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\oceanicnext]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-oceanicnext]
 
 ; Default Foreground
 ; base05 #c0c5ce

--- a/putty/base16-one-light.reg
+++ b/putty/base16-one-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 One Light
+; Scheme name: One Light
+; Scheme system: base16
 ; Scheme author: Daniel Pfeifer (http://github.com/purpleKarrot)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\one-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-one-light]
 
 ; Default Foreground
 ; base05 #383a42

--- a/putty/base16-onedark.reg
+++ b/putty/base16-onedark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 OneDark
+; Scheme name: OneDark
+; Scheme system: base16
 ; Scheme author: Lalit Magant (http://github.com/tilal6991)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\onedark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-onedark]
 
 ; Default Foreground
 ; base05 #abb2bf

--- a/putty/base16-outrun-dark.reg
+++ b/putty/base16-outrun-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Outrun Dark
+; Scheme name: Outrun Dark
+; Scheme system: base16
 ; Scheme author: Hugo Delahousse (http://github.com/hugodelahousse/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\outrun-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-outrun-dark]
 
 ; Default Foreground
 ; base05 #d0d0fa

--- a/putty/base16-oxocarbon-dark.reg
+++ b/putty/base16-oxocarbon-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Oxocarbon Dark
+; Scheme name: Oxocarbon Dark
+; Scheme system: base16
 ; Scheme author: shaunsingh/IBM
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\oxocarbon-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-oxocarbon-dark]
 
 ; Default Foreground
 ; base05 #f2f4f8

--- a/putty/base16-oxocarbon-light.reg
+++ b/putty/base16-oxocarbon-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Oxocarbon Light
+; Scheme name: Oxocarbon Light
+; Scheme system: base16
 ; Scheme author: shaunsingh/IBM
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\oxocarbon-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-oxocarbon-light]
 
 ; Default Foreground
 ; base05 #393939

--- a/putty/base16-pandora.reg
+++ b/putty/base16-pandora.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 pandora
+; Scheme name: pandora
+; Scheme system: base16
 ; Scheme author: Cassandra Fox
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\pandora]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-pandora]
 
 ; Default Foreground
 ; base05 #f15c99

--- a/putty/base16-papercolor-dark.reg
+++ b/putty/base16-papercolor-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 PaperColor Dark
+; Scheme name: PaperColor Dark
+; Scheme system: base16
 ; Scheme author: Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\papercolor-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-papercolor-dark]
 
 ; Default Foreground
 ; base05 #808080

--- a/putty/base16-papercolor-light.reg
+++ b/putty/base16-papercolor-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 PaperColor Light
+; Scheme name: PaperColor Light
+; Scheme system: base16
 ; Scheme author: Jon Leopard (http://github.com/jonleopard) based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\papercolor-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-papercolor-light]
 
 ; Default Foreground
 ; base05 #444444

--- a/putty/base16-paraiso.reg
+++ b/putty/base16-paraiso.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Paraiso
+; Scheme name: Paraiso
+; Scheme system: base16
 ; Scheme author: Jan T. Sott
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\paraiso]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-paraiso]
 
 ; Default Foreground
 ; base05 #a39e9b

--- a/putty/base16-pasque.reg
+++ b/putty/base16-pasque.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Pasque
+; Scheme name: Pasque
+; Scheme system: base16
 ; Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\pasque]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-pasque]
 
 ; Default Foreground
 ; base05 #dedcdf

--- a/putty/base16-phd.reg
+++ b/putty/base16-phd.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 PhD
+; Scheme name: PhD
+; Scheme system: base16
 ; Scheme author: Hennig Hasemann (http://leetless.de/vim.html)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\phd]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-phd]
 
 ; Default Foreground
 ; base05 #b8bbc2

--- a/putty/base16-pico.reg
+++ b/putty/base16-pico.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Pico
+; Scheme name: Pico
+; Scheme system: base16
 ; Scheme author: PICO-8 (http://www.lexaloffle.com/pico-8.php)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\pico]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-pico]
 
 ; Default Foreground
 ; base05 #5f574f

--- a/putty/base16-pinky.reg
+++ b/putty/base16-pinky.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 pinky
+; Scheme name: pinky
+; Scheme system: base16
 ; Scheme author: Benjamin (https://github.com/b3nj5m1n)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\pinky]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-pinky]
 
 ; Default Foreground
 ; base05 #f5f5f5

--- a/putty/base16-pop.reg
+++ b/putty/base16-pop.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Pop
+; Scheme name: Pop
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\pop]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-pop]
 
 ; Default Foreground
 ; base05 #d0d0d0

--- a/putty/base16-porple.reg
+++ b/putty/base16-porple.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Porple
+; Scheme name: Porple
+; Scheme system: base16
 ; Scheme author: Niek den Breeje (https://github.com/AuditeMarlow)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\porple]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-porple]
 
 ; Default Foreground
 ; base05 #d8d8d8

--- a/putty/base16-primer-dark-dimmed.reg
+++ b/putty/base16-primer-dark-dimmed.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Primer Dark Dimmed
+; Scheme name: Primer Dark Dimmed
+; Scheme system: base16
 ; Scheme author: Jimmy Lin
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\primer-dark-dimmed]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-primer-dark-dimmed]
 
 ; Default Foreground
 ; base05 #909dab

--- a/putty/base16-primer-dark.reg
+++ b/putty/base16-primer-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Primer Dark
+; Scheme name: Primer Dark
+; Scheme system: base16
 ; Scheme author: Jimmy Lin
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\primer-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-primer-dark]
 
 ; Default Foreground
 ; base05 #b1bac4

--- a/putty/base16-primer-light.reg
+++ b/putty/base16-primer-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Primer Light
+; Scheme name: Primer Light
+; Scheme system: base16
 ; Scheme author: Jimmy Lin
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\primer-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-primer-light]
 
 ; Default Foreground
 ; base05 #2f363d

--- a/putty/base16-purpledream.reg
+++ b/putty/base16-purpledream.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Purpledream
+; Scheme name: Purpledream
+; Scheme system: base16
 ; Scheme author: malet
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\purpledream]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-purpledream]
 
 ; Default Foreground
 ; base05 #ddd0dd

--- a/putty/base16-qualia.reg
+++ b/putty/base16-qualia.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Qualia
+; Scheme name: Qualia
+; Scheme system: base16
 ; Scheme author: isaacwhanson
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\qualia]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-qualia]
 
 ; Default Foreground
 ; base05 #c0c0c0

--- a/putty/base16-railscasts.reg
+++ b/putty/base16-railscasts.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Railscasts
+; Scheme name: Railscasts
+; Scheme system: base16
 ; Scheme author: Ryan Bates (http://railscasts.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\railscasts]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-railscasts]
 
 ; Default Foreground
 ; base05 #e6e1dc

--- a/putty/base16-rebecca.reg
+++ b/putty/base16-rebecca.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Rebecca
+; Scheme name: Rebecca
+; Scheme system: base16
 ; Scheme author: Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\rebecca]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-rebecca]
 
 ; Default Foreground
 ; base05 #f1eff8

--- a/putty/base16-rose-pine-dawn.reg
+++ b/putty/base16-rose-pine-dawn.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Rosé Pine Dawn
+; Scheme name: Rosé Pine Dawn
+; Scheme system: base16
 ; Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\rose-pine-dawn]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-rose-pine-dawn]
 
 ; Default Foreground
 ; base05 #575279

--- a/putty/base16-rose-pine-moon.reg
+++ b/putty/base16-rose-pine-moon.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Rosé Pine Moon
+; Scheme name: Rosé Pine Moon
+; Scheme system: base16
 ; Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\rose-pine-moon]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-rose-pine-moon]
 
 ; Default Foreground
 ; base05 #e0def4

--- a/putty/base16-rose-pine.reg
+++ b/putty/base16-rose-pine.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Rosé Pine
+; Scheme name: Rosé Pine
+; Scheme system: base16
 ; Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\rose-pine]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-rose-pine]
 
 ; Default Foreground
 ; base05 #e0def4

--- a/putty/base16-saga.reg
+++ b/putty/base16-saga.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 SAGA
+; Scheme name: SAGA
+; Scheme system: base16
 ; Scheme author: https://github.com/SAGAtheme/SAGA
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\saga]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-saga]
 
 ; Default Foreground
 ; base05 #dce2f7

--- a/putty/base16-sagelight.reg
+++ b/putty/base16-sagelight.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Sagelight
+; Scheme name: Sagelight
+; Scheme system: base16
 ; Scheme author: Carter Veldhuizen
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\sagelight]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-sagelight]
 
 ; Default Foreground
 ; base05 #383838

--- a/putty/base16-sakura.reg
+++ b/putty/base16-sakura.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Sakura
+; Scheme name: Sakura
+; Scheme system: base16
 ; Scheme author: Misterio77 (http://github.com/Misterio77)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\sakura]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-sakura]
 
 ; Default Foreground
 ; base05 #564448

--- a/putty/base16-sandcastle.reg
+++ b/putty/base16-sandcastle.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Sandcastle
+; Scheme name: Sandcastle
+; Scheme system: base16
 ; Scheme author: George Essig (https://github.com/gessig)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\sandcastle]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-sandcastle]
 
 ; Default Foreground
 ; base05 #a89984

--- a/putty/base16-selenized-black.reg
+++ b/putty/base16-selenized-black.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 selenized-black
+; Scheme name: selenized-black
+; Scheme system: base16
 ; Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\selenized-black]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-selenized-black]
 
 ; Default Foreground
 ; base05 #b9b9b9

--- a/putty/base16-selenized-dark.reg
+++ b/putty/base16-selenized-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 selenized-dark
+; Scheme name: selenized-dark
+; Scheme system: base16
 ; Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\selenized-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-selenized-dark]
 
 ; Default Foreground
 ; base05 #adbcbc

--- a/putty/base16-selenized-light.reg
+++ b/putty/base16-selenized-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 selenized-light
+; Scheme name: selenized-light
+; Scheme system: base16
 ; Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\selenized-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-selenized-light]
 
 ; Default Foreground
 ; base05 #53676d

--- a/putty/base16-selenized-white.reg
+++ b/putty/base16-selenized-white.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 selenized-white
+; Scheme name: selenized-white
+; Scheme system: base16
 ; Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\selenized-white]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-selenized-white]
 
 ; Default Foreground
 ; base05 #474747

--- a/putty/base16-seti.reg
+++ b/putty/base16-seti.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Seti UI
+; Scheme name: Seti UI
+; Scheme system: base16
 ; Scheme author: 
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\seti]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-seti]
 
 ; Default Foreground
 ; base05 #d6d6d6

--- a/putty/base16-shades-of-purple.reg
+++ b/putty/base16-shades-of-purple.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Shades of Purple
+; Scheme name: Shades of Purple
+; Scheme system: base16
 ; Scheme author: Iolar Demartini Junior (http://github.com/demartini) based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode).
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\shades-of-purple]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-shades-of-purple]
 
 ; Default Foreground
 ; base05 #c7c7c7

--- a/putty/base16-shadesmear-dark.reg
+++ b/putty/base16-shadesmear-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 ShadeSmear Dark
+; Scheme name: ShadeSmear Dark
+; Scheme system: base16
 ; Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\shadesmear-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-shadesmear-dark]
 
 ; Default Foreground
 ; base05 #dbdbdb

--- a/putty/base16-shadesmear-light.reg
+++ b/putty/base16-shadesmear-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 ShadeSmear Light
+; Scheme name: ShadeSmear Light
+; Scheme system: base16
 ; Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\shadesmear-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-shadesmear-light]
 
 ; Default Foreground
 ; base05 #232323

--- a/putty/base16-shapeshifter.reg
+++ b/putty/base16-shapeshifter.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Shapeshifter
+; Scheme name: Shapeshifter
+; Scheme system: base16
 ; Scheme author: Tyler Benziger (http://tybenz.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\shapeshifter]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-shapeshifter]
 
 ; Default Foreground
 ; base05 #102015

--- a/putty/base16-silk-dark.reg
+++ b/putty/base16-silk-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Silk Dark
+; Scheme name: Silk Dark
+; Scheme system: base16
 ; Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\silk-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-silk-dark]
 
 ; Default Foreground
 ; base05 #c7dbdd

--- a/putty/base16-silk-light.reg
+++ b/putty/base16-silk-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Silk Light
+; Scheme name: Silk Light
+; Scheme system: base16
 ; Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\silk-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-silk-light]
 
 ; Default Foreground
 ; base05 #385156

--- a/putty/base16-snazzy.reg
+++ b/putty/base16-snazzy.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Snazzy
+; Scheme name: Snazzy
+; Scheme system: base16
 ; Scheme author: Chawye Hsu (https://github.com/chawyehsu) based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\snazzy]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-snazzy]
 
 ; Default Foreground
 ; base05 #e2e4e5

--- a/putty/base16-solarflare-light.reg
+++ b/putty/base16-solarflare-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Solar Flare Light
+; Scheme name: Solar Flare Light
+; Scheme system: base16
 ; Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\solarflare-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-solarflare-light]
 
 ; Default Foreground
 ; base05 #586875

--- a/putty/base16-solarflare.reg
+++ b/putty/base16-solarflare.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Solar Flare
+; Scheme name: Solar Flare
+; Scheme system: base16
 ; Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\solarflare]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-solarflare]
 
 ; Default Foreground
 ; base05 #a6afb8

--- a/putty/base16-solarized-dark.reg
+++ b/putty/base16-solarized-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Solarized Dark
+; Scheme name: Solarized Dark
+; Scheme system: base16
 ; Scheme author: Ethan Schoonover (modified by aramisgithub)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\solarized-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-solarized-dark]
 
 ; Default Foreground
 ; base05 #93a1a1

--- a/putty/base16-solarized-light.reg
+++ b/putty/base16-solarized-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Solarized Light
+; Scheme name: Solarized Light
+; Scheme system: base16
 ; Scheme author: Ethan Schoonover (modified by aramisgithub)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\solarized-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-solarized-light]
 
 ; Default Foreground
 ; base05 #586e75

--- a/putty/base16-spaceduck.reg
+++ b/putty/base16-spaceduck.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Spaceduck
+; Scheme name: Spaceduck
+; Scheme system: base16
 ; Scheme author: Guillermo Rodriguez (https://github.com/pineapplegiant), packaged by Gabriel Fontes (https://github.com/Misterio77)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\spaceduck]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-spaceduck]
 
 ; Default Foreground
 ; base05 #ecf0c1

--- a/putty/base16-spacemacs.reg
+++ b/putty/base16-spacemacs.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Spacemacs
+; Scheme name: Spacemacs
+; Scheme system: base16
 ; Scheme author: Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\spacemacs]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-spacemacs]
 
 ; Default Foreground
 ; base05 #a3a3a3

--- a/putty/base16-standardized-dark.reg
+++ b/putty/base16-standardized-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 standardized-dark
+; Scheme name: standardized-dark
+; Scheme system: base16
 ; Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\standardized-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-standardized-dark]
 
 ; Default Foreground
 ; base05 #c0c0c0

--- a/putty/base16-standardized-light.reg
+++ b/putty/base16-standardized-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 standardized-light
+; Scheme name: standardized-light
+; Scheme system: base16
 ; Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\standardized-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-standardized-light]
 
 ; Default Foreground
 ; base05 #444444

--- a/putty/base16-stella.reg
+++ b/putty/base16-stella.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Stella
+; Scheme name: Stella
+; Scheme system: base16
 ; Scheme author: Shrimpram
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\stella]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-stella]
 
 ; Default Foreground
 ; base05 #998bad

--- a/putty/base16-still-alive.reg
+++ b/putty/base16-still-alive.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Still Alive
+; Scheme name: Still Alive
+; Scheme system: base16
 ; Scheme author: Derrick McKee (derrick.mckee@gmail.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\still-alive]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-still-alive]
 
 ; Default Foreground
 ; base05 #d80000

--- a/putty/base16-summercamp.reg
+++ b/putty/base16-summercamp.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 summercamp
+; Scheme name: summercamp
+; Scheme system: base16
 ; Scheme author: zoe firi (zoefiri.github.io)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\summercamp]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-summercamp]
 
 ; Default Foreground
 ; base05 #736e55

--- a/putty/base16-summerfruit-dark.reg
+++ b/putty/base16-summerfruit-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Summerfruit Dark
+; Scheme name: Summerfruit Dark
+; Scheme system: base16
 ; Scheme author: Christopher Corley (http://christop.club/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\summerfruit-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-summerfruit-dark]
 
 ; Default Foreground
 ; base05 #d0d0d0

--- a/putty/base16-summerfruit-light.reg
+++ b/putty/base16-summerfruit-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Summerfruit Light
+; Scheme name: Summerfruit Light
+; Scheme system: base16
 ; Scheme author: Christopher Corley (http://christop.club/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\summerfruit-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-summerfruit-light]
 
 ; Default Foreground
 ; base05 #101010

--- a/putty/base16-synth-midnight-dark.reg
+++ b/putty/base16-synth-midnight-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Synth Midnight Terminal Dark
+; Scheme name: Synth Midnight Terminal Dark
+; Scheme system: base16
 ; Scheme author: Michaël Ball (http://github.com/michael-ball/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\synth-midnight-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-synth-midnight-dark]
 
 ; Default Foreground
 ; base05 #c1c3c4

--- a/putty/base16-synth-midnight-light.reg
+++ b/putty/base16-synth-midnight-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Synth Midnight Terminal Light
+; Scheme name: Synth Midnight Terminal Light
+; Scheme system: base16
 ; Scheme author: Michaël Ball (http://github.com/michael-ball/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\synth-midnight-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-synth-midnight-light]
 
 ; Default Foreground
 ; base05 #28292a

--- a/putty/base16-tango.reg
+++ b/putty/base16-tango.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tango
+; Scheme name: Tango
+; Scheme system: base16
 ; Scheme author: @Schnouki, based on the Tango Desktop Project
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tango]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tango]
 
 ; Default Foreground
 ; base05 #d3d7cf

--- a/putty/base16-tarot.reg
+++ b/putty/base16-tarot.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 tarot
+; Scheme name: tarot
+; Scheme system: base16
 ; Scheme author: ed (https://codeberg.org/ed)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tarot]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tarot]
 
 ; Default Foreground
 ; base05 #aa556f

--- a/putty/base16-tender.reg
+++ b/putty/base16-tender.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 tender
+; Scheme name: tender
+; Scheme system: base16
 ; Scheme author: Jacobo Tabernero (https://github/com/jacoborus/tender.vim)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tender]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tender]
 
 ; Default Foreground
 ; base05 #eeeeee

--- a/putty/base16-tokyo-city-dark.reg
+++ b/putty/base16-tokyo-city-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo City Dark
+; Scheme name: Tokyo City Dark
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-city-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-city-dark]
 
 ; Default Foreground
 ; base05 #d8e2ec

--- a/putty/base16-tokyo-city-light.reg
+++ b/putty/base16-tokyo-city-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo City Light
+; Scheme name: Tokyo City Light
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-city-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-city-light]
 
 ; Default Foreground
 ; base05 #343b59

--- a/putty/base16-tokyo-city-terminal-dark.reg
+++ b/putty/base16-tokyo-city-terminal-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo City Terminal Dark
+; Scheme name: Tokyo City Terminal Dark
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-city-terminal-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-city-terminal-dark]
 
 ; Default Foreground
 ; base05 #d8e2ec

--- a/putty/base16-tokyo-city-terminal-light.reg
+++ b/putty/base16-tokyo-city-terminal-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo City Terminal Light
+; Scheme name: Tokyo City Terminal Light
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-city-terminal-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-city-terminal-light]
 
 ; Default Foreground
 ; base05 #28323a

--- a/putty/base16-tokyo-night-dark.reg
+++ b/putty/base16-tokyo-night-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo Night Dark
+; Scheme name: Tokyo Night Dark
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-night-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-night-dark]
 
 ; Default Foreground
 ; base05 #a9b1d6

--- a/putty/base16-tokyo-night-light.reg
+++ b/putty/base16-tokyo-night-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo Night Light
+; Scheme name: Tokyo Night Light
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-night-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-night-light]
 
 ; Default Foreground
 ; base05 #343b59

--- a/putty/base16-tokyo-night-storm.reg
+++ b/putty/base16-tokyo-night-storm.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo Night Storm
+; Scheme name: Tokyo Night Storm
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-night-storm]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-night-storm]
 
 ; Default Foreground
 ; base05 #a9b1d6

--- a/putty/base16-tokyo-night-terminal-dark.reg
+++ b/putty/base16-tokyo-night-terminal-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo Night Terminal Dark
+; Scheme name: Tokyo Night Terminal Dark
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-night-terminal-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-night-terminal-dark]
 
 ; Default Foreground
 ; base05 #787c99

--- a/putty/base16-tokyo-night-terminal-light.reg
+++ b/putty/base16-tokyo-night-terminal-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo Night Terminal Light
+; Scheme name: Tokyo Night Terminal Light
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-night-terminal-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-night-terminal-light]
 
 ; Default Foreground
 ; base05 #4c505e

--- a/putty/base16-tokyo-night-terminal-storm.reg
+++ b/putty/base16-tokyo-night-terminal-storm.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyo Night Terminal Storm
+; Scheme name: Tokyo Night Terminal Storm
+; Scheme system: base16
 ; Scheme author: Michaël Ball
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyo-night-terminal-storm]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyo-night-terminal-storm]
 
 ; Default Foreground
 ; base05 #787c99

--- a/putty/base16-tokyodark-terminal.reg
+++ b/putty/base16-tokyodark-terminal.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyodark Terminal
+; Scheme name: Tokyodark Terminal
+; Scheme system: base16
 ; Scheme author: Tiagovla (https://github.com/tiagovla/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyodark-terminal]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyodark-terminal]
 
 ; Default Foreground
 ; base05 #a0a8cd

--- a/putty/base16-tokyodark.reg
+++ b/putty/base16-tokyodark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tokyodark
+; Scheme name: Tokyodark
+; Scheme system: base16
 ; Scheme author: Tiagovla (https://github.com/tiagovla/)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tokyodark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tokyodark]
 
 ; Default Foreground
 ; base05 #abb2bf

--- a/putty/base16-tomorrow-night-eighties.reg
+++ b/putty/base16-tomorrow-night-eighties.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tomorrow Night Eighties
+; Scheme name: Tomorrow Night Eighties
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tomorrow-night-eighties]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tomorrow-night-eighties]
 
 ; Default Foreground
 ; base05 #cccccc

--- a/putty/base16-tomorrow-night.reg
+++ b/putty/base16-tomorrow-night.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tomorrow Night
+; Scheme name: Tomorrow Night
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tomorrow-night]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tomorrow-night]
 
 ; Default Foreground
 ; base05 #c5c8c6

--- a/putty/base16-tomorrow.reg
+++ b/putty/base16-tomorrow.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Tomorrow
+; Scheme name: Tomorrow
+; Scheme system: base16
 ; Scheme author: Chris Kempson (http://chriskempson.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tomorrow]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tomorrow]
 
 ; Default Foreground
 ; base05 #4d4d4c

--- a/putty/base16-tube.reg
+++ b/putty/base16-tube.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 London Tube
+; Scheme name: London Tube
+; Scheme system: base16
 ; Scheme author: Jan T. Sott
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\tube]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-tube]
 
 ; Default Foreground
 ; base05 #d9d8d8

--- a/putty/base16-twilight.reg
+++ b/putty/base16-twilight.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Twilight
+; Scheme name: Twilight
+; Scheme system: base16
 ; Scheme author: David Hart (https://github.com/hartbit)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\twilight]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-twilight]
 
 ; Default Foreground
 ; base05 #a7a7a7

--- a/putty/base16-unikitty-dark.reg
+++ b/putty/base16-unikitty-dark.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Unikitty Dark
+; Scheme name: Unikitty Dark
+; Scheme system: base16
 ; Scheme author: Josh W Lewis (@joshwlewis)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\unikitty-dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-unikitty-dark]
 
 ; Default Foreground
 ; base05 #bcbabe

--- a/putty/base16-unikitty-light.reg
+++ b/putty/base16-unikitty-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Unikitty Light
+; Scheme name: Unikitty Light
+; Scheme system: base16
 ; Scheme author: Josh W Lewis (@joshwlewis)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\unikitty-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-unikitty-light]
 
 ; Default Foreground
 ; base05 #6c696e

--- a/putty/base16-unikitty-reversible.reg
+++ b/putty/base16-unikitty-reversible.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Unikitty Reversible
+; Scheme name: Unikitty Reversible
+; Scheme system: base16
 ; Scheme author: Josh W Lewis (@joshwlewis)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\unikitty-reversible]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-unikitty-reversible]
 
 ; Default Foreground
 ; base05 #c3c2c4

--- a/putty/base16-uwunicorn.reg
+++ b/putty/base16-uwunicorn.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 UwUnicorn
+; Scheme name: UwUnicorn
+; Scheme system: base16
 ; Scheme author: Fernando Marques (https://github.com/RakkiUwU) and Gabriel Fontes (https://github.com/Misterio77)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\uwunicorn]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-uwunicorn]
 
 ; Default Foreground
 ; base05 #eed5d9

--- a/putty/base16-vesper.reg
+++ b/putty/base16-vesper.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Vesper
+; Scheme name: Vesper
+; Scheme system: base16
 ; Scheme author: FormalSnake (https://github.com/formalsnake)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\vesper]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-vesper]
 
 ; Default Foreground
 ; base05 #b7b7b7

--- a/putty/base16-vice.reg
+++ b/putty/base16-vice.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 vice
+; Scheme name: vice
+; Scheme system: base16
 ; Scheme author: Thomas Leon Highbaugh thighbaugh@zoho.com
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\vice]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-vice]
 
 ; Default Foreground
 ; base05 #8b9cbe

--- a/putty/base16-vulcan.reg
+++ b/putty/base16-vulcan.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 vulcan
+; Scheme name: vulcan
+; Scheme system: base16
 ; Scheme author: Andrey Varfolomeev
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\vulcan]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-vulcan]
 
 ; Default Foreground
 ; base05 #5b778c

--- a/putty/base16-windows-10-light.reg
+++ b/putty/base16-windows-10-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows 10 Light
+; Scheme name: Windows 10 Light
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-10-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-10-light]
 
 ; Default Foreground
 ; base05 #767676

--- a/putty/base16-windows-10.reg
+++ b/putty/base16-windows-10.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows 10
+; Scheme name: Windows 10
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-10]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-10]
 
 ; Default Foreground
 ; base05 #cccccc

--- a/putty/base16-windows-95-light.reg
+++ b/putty/base16-windows-95-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows 95 Light
+; Scheme name: Windows 95 Light
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-95-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-95-light]
 
 ; Default Foreground
 ; base05 #545454

--- a/putty/base16-windows-95.reg
+++ b/putty/base16-windows-95.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows 95
+; Scheme name: Windows 95
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-95]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-95]
 
 ; Default Foreground
 ; base05 #a8a8a8

--- a/putty/base16-windows-highcontrast-light.reg
+++ b/putty/base16-windows-highcontrast-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows High Contrast Light
+; Scheme name: Windows High Contrast Light
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-highcontrast-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-highcontrast-light]
 
 ; Default Foreground
 ; base05 #545454

--- a/putty/base16-windows-highcontrast.reg
+++ b/putty/base16-windows-highcontrast.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows High Contrast
+; Scheme name: Windows High Contrast
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-highcontrast]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-highcontrast]
 
 ; Default Foreground
 ; base05 #c0c0c0

--- a/putty/base16-windows-nt-light.reg
+++ b/putty/base16-windows-nt-light.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows NT Light
+; Scheme name: Windows NT Light
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-nt-light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-nt-light]
 
 ; Default Foreground
 ; base05 #808080

--- a/putty/base16-windows-nt.reg
+++ b/putty/base16-windows-nt.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Windows NT
+; Scheme name: Windows NT
+; Scheme system: base16
 ; Scheme author: Fergus Collins (https://github.com/C-Fergus)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\windows-nt]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-windows-nt]
 
 ; Default Foreground
 ; base05 #c0c0c0

--- a/putty/base16-woodland.reg
+++ b/putty/base16-woodland.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Woodland
+; Scheme name: Woodland
+; Scheme system: base16
 ; Scheme author: Jay Cornwall (https://jcornwall.com)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\woodland]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-woodland]
 
 ; Default Foreground
 ; base05 #cabcb1

--- a/putty/base16-xcode-dusk.reg
+++ b/putty/base16-xcode-dusk.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 XCode Dusk
+; Scheme name: XCode Dusk
+; Scheme system: base16
 ; Scheme author: Elsa Gonsiorowski (https://github.com/gonsie)
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\xcode-dusk]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-xcode-dusk]
 
 ; Default Foreground
 ; base05 #939599

--- a/putty/base16-zenbones.reg
+++ b/putty/base16-zenbones.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Zenbones
+; Scheme name: Zenbones
+; Scheme system: base16
 ; Scheme author: mcchrish
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\zenbones]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-zenbones]
 
 ; Default Foreground
 ; base05 #b279a7

--- a/putty/base16-zenburn.reg
+++ b/putty/base16-zenburn.reg
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 Zenburn
+; Scheme name: Zenburn
+; Scheme system: base16
 ; Scheme author: elnawe
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\zenburn]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base16-zenburn]
 
 ; Default Foreground
 ; base05 #dcdccc

--- a/putty/base24-brogrammer.reg
+++ b/putty/base24-brogrammer.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Brogrammer
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-brogrammer]
+
+; Default Foreground
+; base05 #c1c8d7
+"Colour0"="193,200,215"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #c1c8d7
+"Colour1"="193,200,215"
+
+; Default Background
+; base00 #131313
+"Colour2"="19,19,19"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #131313
+"Colour3"="19,19,19"
+
+; Cursor Text -- equals to default background
+; base00 #131313
+"Colour4"="19,19,19"
+
+; Cursor Colour -- equals to default foreground
+; base05 #c1c8d7
+"Colour5"="193,200,215"
+
+; ANSI Black
+; 30m
+; base00 #131313
+"Colour6"="19,19,19"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #2a3141
+"Colour7"="42,52,46"
+
+; ANSI Red
+; 31m
+; base08 #f71118
+"Colour8"="247,17,24"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #de342e
+"Colour9"="222,52,46"
+
+; ANSI Green
+; 32m
+; base0B #2cc55d
+"Colour10"="44,197,93"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #1dd260
+"Colour11"="29,210,96"
+
+; ANSI Yellow
+; 33m
+; base0A #0f80d5
+"Colour12"="15,128,213"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #f2bd09
+"Colour13"="242,189,9"
+
+; ANSI Blue
+; 34m
+; base0D #2a84d2
+"Colour14"="42,132,210"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #509bdc
+"Colour15"="80,155,220"
+
+; ANSI Magenta
+; 35m
+; base0E #4e59b7
+"Colour16"="78,89,183"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #524fb9
+"Colour17"="82,79,185"
+
+; ANSI Cyan
+; 36m
+; base0C #0f80d5
+"Colour18"="15,128,213"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #289af0
+"Colour19"="40,154,240"
+
+; ANSI White
+; 37m
+; base05 #c1c8d7
+"Colour20"="193,200,215"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-chalk.reg
+++ b/putty/base24-chalk.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Chalk
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-chalk]
+
+; Default Foreground
+; base05 #d0d0d0
+"Colour0"="208,208,208"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #d0d0d0
+"Colour1"="208,208,208"
+
+; Default Background
+; base00 #151515
+"Colour2"="21,21,21"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #151515
+"Colour3"="21,21,21"
+
+; Cursor Text -- equals to default background
+; base00 #151515
+"Colour4"="21,21,21"
+
+; Cursor Colour -- equals to default foreground
+; base05 #d0d0d0
+"Colour5"="208,208,208"
+
+; ANSI Black
+; 30m
+; base00 #151515
+"Colour6"="21,21,21"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #303030
+"Colour7"="48,159,177"
+
+; ANSI Red
+; 31m
+; base08 #fa859c
+"Colour8"="250,133,156"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #fb9fb1
+"Colour9"="251,159,177"
+
+; ANSI Green
+; 32m
+; base0B #a1bb54
+"Colour10"="161,187,84"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #acc267
+"Colour11"="172,194,103"
+
+; ANSI Yellow
+; 33m
+; base0A #ddb26f
+"Colour12"="221,178,111"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #eda987
+"Colour13"="237,169,135"
+
+; ANSI Blue
+; 34m
+; base0D #5ab9ed
+"Colour14"="90,185,237"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #6fc2ef
+"Colour15"="111,194,239"
+
+; ANSI Magenta
+; 35m
+; base0E #db8fea
+"Colour16"="219,143,234"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #e1a3ee
+"Colour17"="225,163,238"
+
+; ANSI Cyan
+; 36m
+; base0C #10bcad
+"Colour18"="16,188,173"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #12cfc0
+"Colour19"="18,207,192"
+
+; ANSI White
+; 37m
+; base05 #d0d0d0
+"Colour20"="208,208,208"
+
+; ANSI White Bright
+; 1;37m
+; base07 f5f5f5
+"Colour21"="245,245,245"

--- a/putty/base24-dracula.reg
+++ b/putty/base24-dracula.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Dracula
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-dracula]
+
+; Default Foreground
+; base05 #e9e9f4
+"Colour0"="233,233,244"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #e9e9f4
+"Colour1"="233,233,244"
+
+; Default Background
+; base00 #21222c
+"Colour2"="33,34,44"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #21222c
+"Colour3"="33,34,44"
+
+; Cursor Text -- equals to default background
+; base00 #21222c
+"Colour4"="33,34,44"
+
+; Cursor Colour -- equals to default foreground
+; base05 #e9e9f4
+"Colour5"="233,233,244"
+
+; ANSI Black
+; 30m
+; base00 #21222c
+"Colour6"="33,34,44"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #3a3c4e
+"Colour7"="58,110,110"
+
+; ANSI Red
+; 31m
+; base08 #ff5555
+"Colour8"="255,85,85"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #ff6e6e
+"Colour9"="255,110,110"
+
+; ANSI Green
+; 32m
+; base0B #50fa7b
+"Colour10"="80,250,123"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #69ff94
+"Colour11"="105,255,148"
+
+; ANSI Yellow
+; 33m
+; base0A #ebff87
+"Colour12"="235,255,135"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #ffffa5
+"Colour13"="255,255,165"
+
+; ANSI Blue
+; 34m
+; base0D #bd93f9
+"Colour14"="189,147,249"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #d6acff
+"Colour15"="214,172,255"
+
+; ANSI Magenta
+; 35m
+; base0E #ff79c6
+"Colour16"="255,121,198"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #ff92df
+"Colour17"="255,146,223"
+
+; ANSI Cyan
+; 36m
+; base0C #8be9fd
+"Colour18"="139,233,253"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #a4ffff
+"Colour19"="164,255,255"
+
+; ANSI White
+; 37m
+; base05 #e9e9f4
+"Colour20"="233,233,244"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-espresso.reg
+++ b/putty/base24-espresso.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Espresso
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-espresso]
+
+; Default Foreground
+; base05 #c7c7c5
+"Colour0"="199,199,197"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #c7c7c5
+"Colour1"="199,199,197"
+
+; Default Background
+; base00 #262626
+"Colour2"="38,38,38"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #262626
+"Colour3"="38,38,38"
+
+; Cursor Text -- equals to default background
+; base00 #262626
+"Colour4"="38,38,38"
+
+; Cursor Colour -- equals to default foreground
+; base05 #c7c7c5
+"Colour5"="199,199,197"
+
+; ANSI Black
+; 30m
+; base00 #262626
+"Colour6"="38,38,38"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #535353
+"Colour7"="83,12,12"
+
+; ANSI Red
+; 31m
+; base08 #d25151
+"Colour8"="210,81,81"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #f00c0c
+"Colour9"="240,12,12"
+
+; ANSI Green
+; 32m
+; base0B #a5c261
+"Colour10"="165,194,97"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #c2e075
+"Colour11"="194,224,117"
+
+; ANSI Yellow
+; 33m
+; base0A #8ab7d9
+"Colour12"="138,183,217"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #e1e38b
+"Colour13"="225,227,139"
+
+; ANSI Blue
+; 34m
+; base0D #6c99bb
+"Colour14"="108,153,187"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #8ab7d9
+"Colour15"="138,183,217"
+
+; ANSI Magenta
+; 35m
+; base0E #d197d9
+"Colour16"="209,151,217"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #efb5f7
+"Colour17"="239,181,247"
+
+; ANSI Cyan
+; 36m
+; base0C #bed6ff
+"Colour18"="190,214,255"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #dcf3ff
+"Colour19"="220,243,255"
+
+; ANSI White
+; 37m
+; base05 #c7c7c5
+"Colour20"="199,199,197"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-flat.reg
+++ b/putty/base24-flat.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Flat
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-flat]
+
+; Default Foreground
+; base05 #8c939a
+"Colour0"="140,147,154"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #8c939a
+"Colour1"="140,147,154"
+
+; Default Background
+; base00 #082845
+"Colour2"="8,40,69"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #082845
+"Colour3"="8,40,69"
+
+; Cursor Text -- equals to default background
+; base00 #082845
+"Colour4"="8,40,69"
+
+; Cursor Colour -- equals to default foreground
+; base05 #8c939a
+"Colour5"="140,147,154"
+
+; ANSI Black
+; 30m
+; base00 #082845
+"Colour6"="8,40,69"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #2e2e45
+"Colour7"="46,49,46"
+
+; ANSI Red
+; 31m
+; base08 #a82320
+"Colour8"="168,35,32"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #d4312e
+"Colour9"="212,49,46"
+
+; ANSI Green
+; 32m
+; base0B #2d9440
+"Colour10"="45,148,64"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #32a548
+"Colour11"="50,165,72"
+
+; ANSI Yellow
+; 33m
+; base0A #3c7dd2
+"Colour12"="60,125,210"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #e5be0c
+"Colour13"="229,190,12"
+
+; ANSI Blue
+; 34m
+; base0D #3167ac
+"Colour14"="49,103,172"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #3c7dd2
+"Colour15"="60,125,210"
+
+; ANSI Magenta
+; 35m
+; base0E #781aa0
+"Colour16"="120,26,160"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #8230a7
+"Colour17"="130,48,167"
+
+; ANSI Cyan
+; 36m
+; base0C #2c9370
+"Colour18"="44,147,112"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #35b387
+"Colour19"="53,179,135"
+
+; ANSI White
+; 37m
+; base05 #8c939a
+"Colour20"="140,147,154"
+
+; ANSI White Bright
+; 1;37m
+; base07 e7eced
+"Colour21"="231,236,237"

--- a/putty/base24-framer.reg
+++ b/putty/base24-framer.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Framer
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-framer]
+
+; Default Foreground
+; base05 #a9a9a9
+"Colour0"="169,169,169"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #a9a9a9
+"Colour1"="169,169,169"
+
+; Default Background
+; base00 #111111
+"Colour2"="17,17,17"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #111111
+"Colour3"="17,17,17"
+
+; Cursor Text -- equals to default background
+; base00 #111111
+"Colour4"="17,17,17"
+
+; Cursor Colour -- equals to default foreground
+; base05 #a9a9a9
+"Colour5"="169,169,169"
+
+; ANSI Black
+; 30m
+; base00 #111111
+"Colour6"="17,17,17"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #414141
+"Colour7"="65,136,136"
+
+; ANSI Red
+; 31m
+; base08 #ff5555
+"Colour8"="255,85,85"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #ff8888
+"Colour9"="255,136,136"
+
+; ANSI Green
+; 32m
+; base0B #98ec65
+"Colour10"="152,236,101"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #b6f292
+"Colour11"="182,242,146"
+
+; ANSI Yellow
+; 33m
+; base0A #33bbff
+"Colour12"="51,187,255"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #ffd966
+"Colour13"="255,217,102"
+
+; ANSI Blue
+; 34m
+; base0D #00aaff
+"Colour14"="0,170,255"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #33bbff
+"Colour15"="51,187,255"
+
+; ANSI Magenta
+; 35m
+; base0E #aa88ff
+"Colour16"="170,136,255"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #cebbff
+"Colour17"="206,187,255"
+
+; ANSI Cyan
+; 36m
+; base0C #88ddff
+"Colour18"="136,221,255"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #bbecff
+"Colour19"="187,236,255"
+
+; ANSI White
+; 37m
+; base05 #a9a9a9
+"Colour20"="169,169,169"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-github.reg
+++ b/putty/base24-github.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Github
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-github]
+
+; Default Foreground
+; base05 #d8d8d8
+"Colour0"="216,216,216"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #d8d8d8
+"Colour1"="216,216,216"
+
+; Default Background
+; base00 #f4f4f4
+"Colour2"="244,244,244"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #f4f4f4
+"Colour3"="244,244,244"
+
+; Cursor Text -- equals to default background
+; base00 #f4f4f4
+"Colour4"="244,244,244"
+
+; Cursor Colour -- equals to default foreground
+; base05 #d8d8d8
+"Colour5"="216,216,216"
+
+; ANSI Black
+; 30m
+; base00 #f4f4f4
+"Colour6"="244,244,244"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #666666
+"Colour7"="102,0,0"
+
+; ANSI Red
+; 31m
+; base08 #970b16
+"Colour8"="151,11,22"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #de0000
+"Colour9"="222,0,0"
+
+; ANSI Green
+; 32m
+; base0B #07962a
+"Colour10"="7,150,42"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #87d5a2
+"Colour11"="135,213,162"
+
+; ANSI Yellow
+; 33m
+; base0A #2e6cba
+"Colour12"="46,108,186"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #f1d007
+"Colour13"="241,208,7"
+
+; ANSI Blue
+; 34m
+; base0D #003e8a
+"Colour14"="0,62,138"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #2e6cba
+"Colour15"="46,108,186"
+
+; ANSI Magenta
+; 35m
+; base0E #e94691
+"Colour16"="233,70,145"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #ffa29f
+"Colour17"="255,162,159"
+
+; ANSI Cyan
+; 36m
+; base0C #89d1ec
+"Colour18"="137,209,236"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #1cfafe
+"Colour19"="28,250,254"
+
+; ANSI White
+; 37m
+; base05 #d8d8d8
+"Colour20"="216,216,216"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-hardcore.reg
+++ b/putty/base24-hardcore.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: Hardcore
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-hardcore]
+
+; Default Foreground
+; base05 #a9a9a9
+"Colour0"="169,169,169"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #a9a9a9
+"Colour1"="169,169,169"
+
+; Default Background
+; base00 #111111
+"Colour2"="17,17,17"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #111111
+"Colour3"="17,17,17"
+
+; Cursor Text -- equals to default background
+; base00 #111111
+"Colour4"="17,17,17"
+
+; Cursor Colour -- equals to default foreground
+; base05 #a9a9a9
+"Colour5"="169,169,169"
+
+; ANSI Black
+; 30m
+; base00 #111111
+"Colour6"="17,17,17"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #414141
+"Colour7"="65,136,136"
+
+; ANSI Red
+; 31m
+; base08 #ff5555
+"Colour8"="255,85,85"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #ff8888
+"Colour9"="255,136,136"
+
+; ANSI Green
+; 32m
+; base0B #98ec65
+"Colour10"="152,236,101"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #b6f292
+"Colour11"="182,242,146"
+
+; ANSI Yellow
+; 33m
+; base0A #33bbff
+"Colour12"="51,187,255"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #ffd966
+"Colour13"="255,217,102"
+
+; ANSI Blue
+; 34m
+; base0D #00aaff
+"Colour14"="0,170,255"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #33bbff
+"Colour15"="51,187,255"
+
+; ANSI Magenta
+; 35m
+; base0E #aa88ff
+"Colour16"="170,136,255"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #cebbff
+"Colour17"="206,187,255"
+
+; ANSI Cyan
+; 36m
+; base0C #88ddff
+"Colour18"="136,221,255"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #bbecff
+"Colour19"="187,236,255"
+
+; ANSI White
+; 37m
+; base05 #a9a9a9
+"Colour20"="169,169,169"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-one-black.reg
+++ b/putty/base24-one-black.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: One Black
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-one-black]
+
+; Default Foreground
+; base05 #abb2bf
+"Colour0"="171,178,191"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #abb2bf
+"Colour1"="171,178,191"
+
+; Default Background
+; base00 #000000
+"Colour2"="0,0,0"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #000000
+"Colour3"="0,0,0"
+
+; Cursor Text -- equals to default background
+; base00 #000000
+"Colour4"="0,0,0"
+
+; Cursor Colour -- equals to default foreground
+; base05 #abb2bf
+"Colour5"="171,178,191"
+
+; ANSI Black
+; 30m
+; base00 #000000
+"Colour6"="0,0,0"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #4f5666
+"Colour7"="79,97,110"
+
+; ANSI Red
+; 31m
+; base08 #e05561
+"Colour8"="224,85,97"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #ff616e
+"Colour9"="255,97,110"
+
+; ANSI Green
+; 32m
+; base0B #8cc265
+"Colour10"="140,194,101"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #a5e075
+"Colour11"="165,224,117"
+
+; ANSI Yellow
+; 33m
+; base0A #e6b965
+"Colour12"="230,185,101"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #f0a45d
+"Colour13"="240,164,93"
+
+; ANSI Blue
+; 34m
+; base0D #4aa5f0
+"Colour14"="74,165,240"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #4dc4ff
+"Colour15"="77,196,255"
+
+; ANSI Magenta
+; 35m
+; base0E #c162de
+"Colour16"="193,98,222"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #de73ff
+"Colour17"="222,115,255"
+
+; ANSI Cyan
+; 36m
+; base0C #42b3c2
+"Colour18"="66,179,194"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #4cd1e0
+"Colour19"="76,209,224"
+
+; ANSI White
+; 37m
+; base05 #abb2bf
+"Colour20"="171,178,191"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-one-dark.reg
+++ b/putty/base24-one-dark.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: One Dark
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-one-dark]
+
+; Default Foreground
+; base05 #abb2bf
+"Colour0"="171,178,191"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #abb2bf
+"Colour1"="171,178,191"
+
+; Default Background
+; base00 #282c34
+"Colour2"="40,44,52"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #282c34
+"Colour3"="40,44,52"
+
+; Cursor Text -- equals to default background
+; base00 #282c34
+"Colour4"="40,44,52"
+
+; Cursor Colour -- equals to default foreground
+; base05 #abb2bf
+"Colour5"="171,178,191"
+
+; ANSI Black
+; 30m
+; base00 #282c34
+"Colour6"="40,44,52"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #4f5666
+"Colour7"="79,97,110"
+
+; ANSI Red
+; 31m
+; base08 #e05561
+"Colour8"="224,85,97"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #ff616e
+"Colour9"="255,97,110"
+
+; ANSI Green
+; 32m
+; base0B #8cc265
+"Colour10"="140,194,101"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #a5e075
+"Colour11"="165,224,117"
+
+; ANSI Yellow
+; 33m
+; base0A #e6b965
+"Colour12"="230,185,101"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #f0a45d
+"Colour13"="240,164,93"
+
+; ANSI Blue
+; 34m
+; base0D #4aa5f0
+"Colour14"="74,165,240"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #4dc4ff
+"Colour15"="77,196,255"
+
+; ANSI Magenta
+; 35m
+; base0E #c162de
+"Colour16"="193,98,222"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #de73ff
+"Colour17"="222,115,255"
+
+; ANSI Cyan
+; 36m
+; base0C #42b3c2
+"Colour18"="66,179,194"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #4cd1e0
+"Colour19"="76,209,224"
+
+; ANSI White
+; 37m
+; base05 #abb2bf
+"Colour20"="171,178,191"
+
+; ANSI White Bright
+; 1;37m
+; base07 ffffff
+"Colour21"="255,255,255"

--- a/putty/base24-one-light.reg
+++ b/putty/base24-one-light.reg
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: One Light
+; Scheme system: base24
+; Scheme author: FredHappyface (https://github.com/fredHappyface)
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\base24-one-light]
+
+; Default Foreground
+; base05 #383a42
+"Colour0"="56,58,66"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #383a42
+"Colour1"="56,58,66"
+
+; Default Background
+; base00 #e7e7e9
+"Colour2"="231,231,233"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #e7e7e9
+"Colour3"="231,231,233"
+
+; Cursor Text -- equals to default background
+; base00 #e7e7e9
+"Colour4"="231,231,233"
+
+; Cursor Colour -- equals to default foreground
+; base05 #383a42
+"Colour5"="56,58,66"
+
+; ANSI Black
+; 30m
+; base00 #e7e7e9
+"Colour6"="231,231,233"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #cacace
+"Colour7"="202,34,88"
+
+; ANSI Red
+; 31m
+; base08 #ca1243
+"Colour8"="202,18,67"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #ec2258
+"Colour9"="236,34,88"
+
+; ANSI Green
+; 32m
+; base0B #50a14f
+"Colour10"="80,161,79"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #6db76c
+"Colour11"="109,183,108"
+
+; ANSI Yellow
+; 33m
+; base0A #febb2a
+"Colour12"="254,187,42"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #f4a701
+"Colour13"="244,167,1"
+
+; ANSI Blue
+; 34m
+; base0D #4078f2
+"Colour14"="64,120,242"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #709af5
+"Colour15"="112,154,245"
+
+; ANSI Magenta
+; 35m
+; base0E #a626a4
+"Colour16"="166,38,164"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #d02fcd
+"Colour17"="208,47,205"
+
+; ANSI Cyan
+; 36m
+; base0C #0184bc
+"Colour18"="1,132,188"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #01a7ef
+"Colour19"="1,167,239"
+
+; ANSI White
+; 37m
+; base05 #383a42
+"Colour20"="56,58,66"
+
+; ANSI White Bright
+; 1;37m
+; base07 090a0b
+"Colour21"="9,10,11"

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -1,0 +1,111 @@
+Windows Registry Editor Version 5.00
+
+; Scheme name: {{scheme-name}}
+; Scheme system: {{scheme-system}}
+; Scheme author: {{scheme-author}}
+; Template author: Tinted Theming (https://github.com/tinted-theming)
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\{{scheme-system}}-{{scheme-slug}}]
+
+; Default Foreground
+; base05 #{{base05-hex}}
+"Colour0"="{{base05-rgb-r}},{{base05-rgb-g}},{{base05-rgb-b}}"
+
+; Default Bold Foreground  -- equals to non-bold
+; base05 #{{base05-hex}}
+"Colour1"="{{base05-rgb-r}},{{base05-rgb-g}},{{base05-rgb-b}}"
+
+; Default Background
+; base00 #{{base00-hex}}
+"Colour2"="{{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}"
+
+; Default Bold Background  -- equals to non-bold
+; base00 #{{base00-hex}}
+"Colour3"="{{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}"
+
+; Cursor Text -- equals to default background
+; base00 #{{base00-hex}}
+"Colour4"="{{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}"
+
+; Cursor Colour -- equals to default foreground
+; base05 #{{base05-hex}}
+"Colour5"="{{base05-rgb-r}},{{base05-rgb-g}},{{base05-rgb-b}}"
+
+; ANSI Black
+; 30m
+; base00 #{{base00-hex}}
+"Colour6"="{{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}"
+
+; ANSI Black Bright
+; 1;30m
+; base03 #{{base03-hex}}
+"Colour7"="{{base03-rgb-r}},{{base03-rgb-g}},{{base03-rgb-b}}"
+
+; ANSI Red
+; 31m
+; base08 #{{base08-hex}}
+"Colour8"="{{base08-rgb-r}},{{base08-rgb-g}},{{base08-rgb-b}}"
+
+; ANSI Red Bright
+; 1;31m
+; base09 #{{base09-hex}}
+"Colour9"="{{base09-rgb-r}},{{base09-rgb-g}},{{base09-rgb-b}}"
+
+; ANSI Green
+; 32m
+; base0B #{{base0B-hex}}
+"Colour10"="{{base0B-rgb-r}},{{base0B-rgb-g}},{{base0B-rgb-b}}"
+
+; ANSI Green Bright
+; 1;32m
+; base0B #{{base0B-hex}}
+"Colour11"="{{base0B-rgb-r}},{{base0B-rgb-g}},{{base0B-rgb-b}}"
+
+; ANSI Yellow
+; 33m
+; base0A #{{base0A-hex}}
+"Colour12"="{{base0A-rgb-r}},{{base0A-rgb-g}},{{base0A-rgb-b}}"
+
+; ANSI Yellow Bright
+; 1;33m
+; base0A #{{base0A-hex}}
+"Colour13"="{{base0A-rgb-r}},{{base0A-rgb-g}},{{base0A-rgb-b}}"
+
+; ANSI Blue
+; 34m
+; base0D #{{base0D-hex}}
+"Colour14"="{{base0D-rgb-r}},{{base0D-rgb-g}},{{base0D-rgb-b}}"
+
+; ANSI Blue Bright
+; 1;34m
+; base0D #{{base0D-hex}}
+"Colour15"="{{base0D-rgb-r}},{{base0D-rgb-g}},{{base0D-rgb-b}}"
+
+; ANSI Magenta
+; 35m
+; base0E #{{base0E-hex}}
+"Colour16"="{{base0E-rgb-r}},{{base0E-rgb-g}},{{base0E-rgb-b}}"
+
+; ANSI Magenta Bright
+; 1;35m
+; base0E #{{base0E-hex}}
+"Colour17"="{{base0E-rgb-r}},{{base0E-rgb-g}},{{base0E-rgb-b}}"
+
+; ANSI Cyan
+; 36m
+; base0C #{{base0C-hex}}
+"Colour18"="{{base0C-rgb-r}},{{base0C-rgb-g}},{{base0C-rgb-b}}"
+
+; ANSI Cyan Bright
+; 1;36m
+; base0F #{{base0F-hex}}
+"Colour19"="{{base0F-rgb-r}},{{base0F-rgb-g}},{{base0F-rgb-b}}"
+
+; ANSI White
+; 37m
+; base05 #{{base05-hex}}
+"Colour20"="{{base05-rgb-r}},{{base05-rgb-g}},{{base05-rgb-b}}"
+
+; ANSI White Bright
+; 1;37m
+; base07 {{base07-hex}}
+"Colour21"="{{base07-rgb-r}},{{base07-rgb-g}},{{base07-rgb-b}}"

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -1,9 +1,10 @@
 Windows Registry Editor Version 5.00
 
-; Base16 {{scheme-name}}
+; Scheme name: {{scheme-name}}
+; Scheme system: {{scheme-system}}
 ; Scheme author: {{scheme-author}}
 ; Template author: Tinted Theming (https://github.com/tinted-theming)
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\{{scheme-slug}}]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\{{scheme-system}}-{{scheme-slug}}]
 
 ; Default Foreground
 ; base05 #{{base05-hex}}
@@ -30,81 +31,65 @@ Windows Registry Editor Version 5.00
 "Colour5"="{{base05-rgb-r}},{{base05-rgb-g}},{{base05-rgb-b}}"
 
 ; ANSI Black
-; 30m
 ; base00 #{{base00-hex}}
 "Colour6"="{{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}"
 
 ; ANSI Black Bright
-; 1;30m
-; base03 #{{base03-hex}}
-"Colour7"="{{base03-rgb-r}},{{base03-rgb-g}},{{base03-rgb-b}}"
+; base02 #{{base02-hex}}
+"Colour7"="{{base02-rgb-r}},{{base12-rgb-g}},{{base12-rgb-b}}"
 
 ; ANSI Red
-; 31m
 ; base08 #{{base08-hex}}
 "Colour8"="{{base08-rgb-r}},{{base08-rgb-g}},{{base08-rgb-b}}"
 
 ; ANSI Red Bright
-; 1;31m
-; base09 #{{base09-hex}}
-"Colour9"="{{base09-rgb-r}},{{base09-rgb-g}},{{base09-rgb-b}}"
+; base12 #{{base12-hex}}
+"Colour9"="{{base12-rgb-r}},{{base12-rgb-g}},{{base12-rgb-b}}"
 
 ; ANSI Green
-; 32m
 ; base0B #{{base0B-hex}}
 "Colour10"="{{base0B-rgb-r}},{{base0B-rgb-g}},{{base0B-rgb-b}}"
 
 ; ANSI Green Bright
-; 1;32m
-; base0B #{{base0B-hex}}
-"Colour11"="{{base0B-rgb-r}},{{base0B-rgb-g}},{{base0B-rgb-b}}"
+; base14 #{{base14-hex}}
+"Colour11"="{{base14-rgb-r}},{{base14-rgb-g}},{{base14-rgb-b}}"
 
 ; ANSI Yellow
-; 33m
 ; base0A #{{base0A-hex}}
 "Colour12"="{{base0A-rgb-r}},{{base0A-rgb-g}},{{base0A-rgb-b}}"
 
 ; ANSI Yellow Bright
-; 1;33m
-; base0A #{{base0A-hex}}
-"Colour13"="{{base0A-rgb-r}},{{base0A-rgb-g}},{{base0A-rgb-b}}"
+; base13 #{{base13-hex}}
+"Colour13"="{{base13-rgb-r}},{{base13-rgb-g}},{{base13-rgb-b}}"
 
 ; ANSI Blue
-; 34m
 ; base0D #{{base0D-hex}}
 "Colour14"="{{base0D-rgb-r}},{{base0D-rgb-g}},{{base0D-rgb-b}}"
 
 ; ANSI Blue Bright
-; 1;34m
-; base0D #{{base0D-hex}}
-"Colour15"="{{base0D-rgb-r}},{{base0D-rgb-g}},{{base0D-rgb-b}}"
+; base16 #{{base16-hex}}
+"Colour15"="{{base16-rgb-r}},{{base16-rgb-g}},{{base16-rgb-b}}"
 
 ; ANSI Magenta
-; 35m
 ; base0E #{{base0E-hex}}
 "Colour16"="{{base0E-rgb-r}},{{base0E-rgb-g}},{{base0E-rgb-b}}"
 
 ; ANSI Magenta Bright
-; 1;35m
-; base0E #{{base0E-hex}}
-"Colour17"="{{base0E-rgb-r}},{{base0E-rgb-g}},{{base0E-rgb-b}}"
+; base17 #{{base17-hex}}
+"Colour17"="{{base17-rgb-r}},{{base17-rgb-g}},{{base17-rgb-b}}"
 
 ; ANSI Cyan
-; 36m
 ; base0C #{{base0C-hex}}
 "Colour18"="{{base0C-rgb-r}},{{base0C-rgb-g}},{{base0C-rgb-b}}"
 
 ; ANSI Cyan Bright
-; 1;36m
-; base0F #{{base0F-hex}}
-"Colour19"="{{base0F-rgb-r}},{{base0F-rgb-g}},{{base0F-rgb-b}}"
+; base15 #{{base15-hex}}
+"Colour19"="{{base15-rgb-r}},{{base15-rgb-g}},{{base15-rgb-b}}"
 
 ; ANSI White
-; 37m
 ; base05 #{{base05-hex}}
 "Colour20"="{{base05-rgb-r}},{{base05-rgb-g}},{{base05-rgb-b}}"
 
 ; ANSI White Bright
-; 1;37m
 ; base07 {{base07-hex}}
 "Colour21"="{{base07-rgb-r}},{{base07-rgb-g}},{{base07-rgb-b}}"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,3 +1,8 @@
-default:
+base16:
     extension: .reg
     output: putty
+
+base24:
+    extension: .reg
+    output: putty
+    supported-systems: [base24]


### PR DESCRIPTION
## Description

We're moving towards supporting multiple scheme systems with our repos [tinted-sublime-text](https://github.com/tinted-theming/tinted-sublime-text), [tinted-vscode](https://github.com/tinted-theming/tinted-vscode)  we're going to move towards this with our other template repositories too (ie [base16-shell](https://github.com/tinted-theming/base16-shell/pull/53) [base16-tmux](https://github.com/tinted-theming/base16-tmux/pull/22) and base16-vim soon) since it's easier to maintain and easier for users to have access to the different themes without having to add multiple scheme system repos per template.

## PR Changes

- Add base24 template and theme support to repo
- Update readme

## Backwards compatibility

Renaming to `tinted-putty` we need to make sure backwards compatibility is there.

The plan is to rename the repo to https://github.com/tinted-theming/tinted-putty and have github auto redirect from https://github.com/tinted-theming/base16-putty to the new repo.

Any user who has `base16-putty` cloned locally should be able to do a `git pull` and carry on without knowing anything has changed aside from getting more themes in `./putty/base24-*`.
